### PR TITLE
Add dependent workflows

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,38 @@
+name: PHP Compatibility
+
+on: ['workflow_call']
+
+jobs:
+  php-compatibility:
+    name: PHP ${{ matrix.php-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ["7.4", "8.0", "8.1", "8.2"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure PHP environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          extensions: mbstring, intl
+          coverage: none
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: highest
+
+      - name: Run PHP Compatibility
+        run: composer compatibility:php-${{ matrix.php-version }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,20 @@
+name: Coding Standards
+
+on: ['workflow_call']
+
+jobs:
+  phpcs:
+    name: phpcs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure PHP environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+      - uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--ignore-platform-reqs --optimize-autoloader"
+      - name: Run PHPCS
+        run: ./vendor/bin/phpcs

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,20 @@
+name: Static Analysis
+
+on: ['workflow_call']
+
+jobs:
+  phpstan:
+    name: phpstan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure PHP environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+      - uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--ignore-platform-reqs --optimize-autoloader"
+      - name: Run PHPStan
+        run: composer test:analysis

--- a/.github/workflows/slic.yml
+++ b/.github/workflows/slic.yml
@@ -1,0 +1,76 @@
+name: 'Slic Tests'
+
+on: ['workflow_call']
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        suite:
+          - wpunit
+          - unit
+          - functional
+          - acceptance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      # ------------------------------------------------------------------------------
+      # Checkout slic
+      # ------------------------------------------------------------------------------
+      - name: Checkout slic
+        uses: actions/checkout@v2
+        with:
+          repository: stellarwp/slic
+          ref: main
+          path: slic
+          fetch-depth: 1
+
+      # ------------------------------------------------------------------------------
+      # Prepare our composer cache directory
+      # ------------------------------------------------------------------------------
+      - name: Get Composer Cache Directory
+        id: get-composer-cache-dir
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        id: composer-cache
+        with:
+          path: ${{ steps.get-composer-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      # ------------------------------------------------------------------------------
+      # Initialize slic
+      # ------------------------------------------------------------------------------
+      - name: Set up slic env vars
+        run: |
+          echo "SLIC_BIN=${GITHUB_WORKSPACE}/slic/slic" >> $GITHUB_ENV
+          echo "SLIC_WP_DIR=${GITHUB_WORKSPACE}/slic/_wordpress" >> $GITHUB_ENV
+          echo "SLIC_WORDPRESS_DOCKERFILE=Dockerfile.base" >> $GITHUB_ENV
+      - name: Set run context for slic
+        run: echo "SLIC=1" >> $GITHUB_ENV && echo "CI=1" >> $GITHUB_ENV
+      - name: Start ssh-agent
+        run: |
+          mkdir -p "${HOME}/.ssh";
+          ssh-agent -a /tmp/ssh_agent.sock;
+      - name: Export SSH_AUTH_SOCK env var
+        run: echo "SSH_AUTH_SOCK=/tmp/ssh_agent.sock" >> $GITHUB_ENV
+      - name: Set up slic for CI
+        run: |
+          cd ${GITHUB_WORKSPACE}/..
+          ${SLIC_BIN} here
+          ${SLIC_BIN} interactive off
+          ${SLIC_BIN} build-prompt off
+          ${SLIC_BIN} build-subdir off
+          ${SLIC_BIN} xdebug off
+          ${SLIC_BIN} debug on
+          ${SLIC_BIN} info
+          ${SLIC_BIN} config
+      - name: Set up Moose
+        run: |
+          ${SLIC_BIN} use moose
+          ${SLIC_BIN} composer install --ignore-platform-reqs
+      - name: Run suite ${{ matrix.suite }}
+        run: ${SLIC_BIN} run ${{ matrix.suite }} --ext DotReporter

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,20 @@
+name: 'Triage'
+
+on: [push, pull_request]
+
+jobs:
+  coding-standards:
+    name: 'Coding Standards'
+    uses: ./.github/workflows/phpcs.yml
+  phpstan:
+    name: 'Static Analysis'
+    needs: [coding-standards]
+    uses: ./.github/workflows/phpstan.yml
+  compatibility:
+    name: 'PHP Compatibility'
+    needs: [coding-standards, phpstan]
+    uses: ./.github/workflows/compatibility.yml
+  slic:
+    name: 'PHP Tests'
+    needs: [coding-standards, phpstan, compatibility]
+    uses: ./.github/workflows/slic.yml


### PR DESCRIPTION
## What does this do/fix?

This creates some dependent workflows to fail fast/often to conserve Action minutes for unnecessary workflow runs. For example, if there are issues with coding standards, we should fail quickly and wait to run the more intensive workflows until issues are fixed.

The Actions should run in this order and failing steps will halt workflows further down the chain:
1. [Coding Standards](https://github.com/moderntribe/moose/blob/8018cd405916c58d745ae0994d38e418338b2de6/.github/workflows/phpcs.yml)
2. [Static Analysis](https://github.com/moderntribe/moose/blob/8018cd405916c58d745ae0994d38e418338b2de6/.github/workflows/phpstan.yml)
3. [PHP Compatibility](https://github.com/moderntribe/moose/blob/8018cd405916c58d745ae0994d38e418338b2de6/.github/workflows/compatibility.yml)
4. [Slic Automated Tests](https://github.com/moderntribe/moose/blob/8018cd405916c58d745ae0994d38e418338b2de6/.github/workflows/slic.yml)

<img width="1292" alt="Screenshot on 2023-02-13 at 11-03-16" src="https://user-images.githubusercontent.com/6947218/218509124-211285f4-cf2e-415b-a722-3787ae64730b.png">