### PR TITLE
[MOOSE-8] Add light reset/normalize pcss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ wp-content/wp-cache-config.php
 wp-content/tests/
 wp-content/logs/
 wp-content/mu-plugins/mu.local.php
+wp-content/mu-plugins/local-by-flywheel-live-link-helper.php
 
 wp-content/themes/*
 wp-content/plugins/*

--- a/wp-content/themes/core/assets/pcss/admin.pcss
+++ b/wp-content/themes/core/assets/pcss/admin.pcss
@@ -19,4 +19,5 @@
 @import "typography/_utilities.pcss";
 
 /* Global Theme Styles */
+@import "global/reset.pcss";
 @import "typography/anchors.pcss";

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -1,0 +1,76 @@
+/* -------------------------------------------------------------------------
+ *
+ * Global "Resets" & Light Normalize
+ *
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Use a more-intuitive box-sizing model.
+ */
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+/**
+ * Prevent adjustments of font size after orientation changes in iOS.
+ */
+html {
+	text-size-adjust: 100%;
+}
+
+/**
+ * 1. Improve text rendering.
+ * 2. Prevent horizontal scroll.
+ */
+body {
+	-webkit-font-smoothing: antialiased;
+	overflow-x: hidden;
+}
+
+/**
+ * Avoid text overflows.
+ */
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	overflow-wrap: break-word;
+	hyphens: auto;
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+small {
+	font-size: 80%;
+}
+
+img,
+picture {
+	height: auto;
+	max-width: 100%;
+}
+
+iframe,
+video,
+embed {
+	max-width: 100%;
+}
+
+/**
+ * 1. Remove built-in form typography styles and prevent zoom on mobile devices.
+ * 2. Remove margin in Firefox & Safari.
+ */
+input,
+button,
+optgroup,
+textarea,
+select {
+	font: inherit;
+	margin: 0;
+}

--- a/wp-content/themes/core/assets/pcss/theme.pcss
+++ b/wp-content/themes/core/assets/pcss/theme.pcss
@@ -19,4 +19,5 @@
 @import "typography/_utilities.pcss";
 
 /* Global Theme Styles */
+@import "global/reset.pcss";
 @import "typography/anchors.pcss";


### PR DESCRIPTION
## What does this do/fix?

Adds light-touch reset / normalize styles inspired by [Josh Cormeau's reset](https://www.joshwcomeau.com/css/custom-css-reset/) and the latest version of [Normalize.css](https://github.com/necolas/normalize.css/)

It's possible that more form reset styles may be wanted when we begin implementing forms. Overall though, pretty impressive how much browsers have standardized and the amount of old rules I was able to remove.

Testing was done across the following:
- MacOS: Safari, Firefox, Chrome
- iOS: Safari, Chrome
- Android (Samsung Galaxy devices): Chrome, Firefox, system browser

## QA

Links to relevant issues
- [Link to Issue](https://example.com)
