### PR TITLE
Bugfix: Allow use of align wide and full

### DIFF
--- a/wp-content/themes/core/templates/page.html
+++ b/wp-content/themes/core/templates/page.html
@@ -1,5 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 	<!-- wp:post-featured-image /-->
 	<!-- wp:post-title /-->

--- a/wp-content/themes/core/templates/page.html
+++ b/wp-content/themes/core/templates/page.html
@@ -6,7 +6,7 @@
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
-	<!-- wp:post-content /-->
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 	<!-- wp:spacer {"height":100} -->
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->

--- a/wp-content/themes/core/templates/single.html
+++ b/wp-content/themes/core/templates/single.html
@@ -1,5 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 	<!-- wp:post-featured-image /-->
 	<!-- wp:post-title /-->

--- a/wp-content/themes/core/templates/single.html
+++ b/wp-content/themes/core/templates/single.html
@@ -9,7 +9,7 @@
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
-	<!-- wp:post-content /-->
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->


### PR DESCRIPTION
## What does this do/fix?

This was a fun (and frustrating) bug to track down- if “Inner blocks use content width” is disabled on Post Content then root blocks in the post editor won't have wide/full alignment controls

This fix updates the `page.html` and `single.html` templates to allow blocks supporting align wide and align full to appear in the block toolbar.

**Screenshots**:
- Without constrained layout, align options don't appear in block toolbar - http://p.tri.be/i/PV2rkF
- WITH constrained layout, align options reappear in block toolbar - http://p.tri.be/i/xZpLnu

