### PR TITLE
Removes default support for XML-RPC Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2023.05]
+
+- Security: Removed default support for XML-RCP Authentication.
+
 ## [2023.04]
 
 - Added: GitHub actions for Coding Standards, Static Analysis and Testing.

--- a/wp-content/plugins/core/src/Theme_Config/Theme_Config_Subscriber.php
+++ b/wp-content/plugins/core/src/Theme_Config/Theme_Config_Subscriber.php
@@ -41,6 +41,13 @@ class Theme_Config_Subscriber extends Abstract_Subscriber {
 		add_action( 'init', function (): void {
 			$this->container->get( Comment_Support::class )->remove_admin_bar_comments();
 		});
+
+		/**
+		 * Disable XML-RPC authentication support.
+		 *
+		 * @see wp-includes/class-wp-xmlrpc-server.php:219
+		 */
+		add_filter( 'xmlrpc_enabled', '__return_false' );
 	}
 
 }


### PR DESCRIPTION
## What does this do/fix?

Removes default support for XML-RPC authentication.  If the project requires it, we will enable it. In practice, we should have a really good reason why we need it.  Chances are really good that the Rest API can handle what is needed. 