### PR TITLE
[MOOSE-13] add s1 menu functions

### DIFF
--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -34,6 +34,7 @@ class Core {
 		Object_Meta\Meta_Subscriber::class,
 		Settings_Subscriber::class,
 		Theme_Config\Theme_Config_Subscriber::class,
+		Menus\Menu_Subscriber::class,
 	];
 
 	private static self $instance;

--- a/wp-content/plugins/core/src/Menus/Menu_Attribute_Filters.php
+++ b/wp-content/plugins/core/src/Menus/Menu_Attribute_Filters.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Menus;
+
+use stdClass;
+
+/**
+ * Class Menu_Attribute_Filters
+ *
+ * Filters the attributes applied to HTML elements in a nav menu
+ */
+class Menu_Attribute_Filters {
+
+	/**
+	 * Remove the ID attributed from the nav item
+	 *
+	 * @param string    $menu_id The ID that is applied to the menu item's `<li>` element.
+	 * @param object    $item    The current menu item.
+	 * @param \stdClass $args    An object of {@see wp_nav_menu()} arguments.
+	 * @param int       $depth   Depth of menu item. Used for padding.
+	 *
+	 * @filter nav_menu_item_id
+	 */
+	public function customize_nav_item_id( string $menu_id, object $item, stdClass $args, int $depth ): string {
+		return '';
+	}
+
+	/**
+	 * Customize the CSS classes applied to an <li> in the nav menu.
+	 *
+	 * @param array     $classes The CSS classes that are applied to the menu item's `<li>` element.
+	 * @param object    $item    The current menu item.
+	 * @param \stdClass $args    An object of {@see wp_nav_menu()} arguments.
+	 * @param int       $depth   Depth of menu item. Used for padding.
+	 *
+	 * @note   WP Core docs claim that $args is an array, but it comes in as an object thanks to casting in wp_nav_menu().
+	 *
+	 * @return array
+	 *
+	 * @filter nav_menu_css_class
+	 */
+	public function customize_nav_item_classes( array $classes, object $item, stdClass $args, int $depth ): array {
+		if ( empty( $args->theme_location ) ) {
+			return $classes;
+		}
+
+		$theme_location = $args->theme_location;
+
+		$classes[] = 'c-nav-' . $theme_location . '__list-item';
+
+		// Depth
+		$classes[] = 'c-nav-' . $theme_location . '__list-item--depth-' . $depth;
+
+		// Has children items
+		if ( in_array( 'menu-item-has-children', $item->classes ) ) {
+			$classes[] = 'c-nav-' . $theme_location . '__list-item--has-children';
+		}
+
+		// Is Parent Item
+		if ( in_array( 'current-menu-parent', $item->classes ) ) {
+			$classes[] = 'c-nav-' . $theme_location . '__list-item--is-current-parent';
+		}
+
+		// Is Current Item
+		if ( in_array( 'current-menu-item', $item->classes ) ) {
+			$classes[] = 'c-nav-' . $theme_location . '__list-item--is-current';
+		}
+
+		/**
+		 * Filter the array of classes to remove the classes added by WP Core.
+		 * Regex is designed to filter all classes defined in `_wp_menu_item_classes_by_context()`;
+		 */
+		return array_filter( $classes, static function ( $class ) {
+
+			/**
+			 * Patterns used for matching:
+			 *
+			 * ^menu-item[\w|-]*$         Matches classes that start with `menu-item` and may or may not have additional modifiers.
+			 * ^current[-|_][\w|-]*$      Matches classes that start with `current-` or `current_` and have additional modifiers.
+			 * ^page[-|_]item[\w|-]*$     Matches classes that start with `page-item` or `page_item` and may or may not have additional modifiers.
+			 */
+
+			$pattern = '/^menu-item[\w|-]*$|^current[-|_][\w|-]*$|^page[-|_]item[\w|-]*$/iU';
+
+			return ! preg_match( $pattern, $class );
+		} );
+	}
+
+	/**
+	 * Customize WP menu item anchor attributes
+	 *
+	 * @param array     $atts   {
+	 *                          The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
+	 *
+	 * @type string     $title  Title attribute.
+	 * @type string     $target Target attribute.
+	 * @type string     $rel    The rel attribute.
+	 * @type string     $href   The href attribute.
+	 * }
+	 *
+	 * @param object    $item   The current menu item.
+	 * @param \stdClass $args   An object of {@see wp_nav_menu()} arguments.
+	 * @param int       $depth  Depth of menu item. Used for padding.
+	 *
+	 * @return array
+	 *
+	 * @filter nav_menu_link_attributes
+	 */
+	public function customize_nav_item_anchor_atts( array $atts, object $item, stdClass $args, int $depth ): array {
+		if ( empty( $args->theme_location ) ) {
+			return $atts;
+		}
+
+		$theme_location = $args->theme_location;
+
+		$classes = [
+			'c-nav-' . $theme_location . '__action',
+			'c-nav-' . $theme_location . '__action--depth-' . $depth,
+		];
+
+		// Has children items
+		if ( in_array( 'menu-item-has-children', $item->classes ) ) {
+			$classes[] = 'c-nav-' . $theme_location . '__action--has-children';
+		}
+
+		$atts['class'] = implode( ' ', array_unique( $classes ) );
+
+		return $atts;
+	}
+
+}

--- a/wp-content/plugins/core/src/Menus/Menu_Subscriber.php
+++ b/wp-content/plugins/core/src/Menus/Menu_Subscriber.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Menus;
+
+use Tribe\Libs\Container\Abstract_Subscriber;
+
+class Menu_Subscriber extends Abstract_Subscriber {
+
+	public function register(): void {
+		$this->nav_attributes();
+	}
+
+	private function nav_attributes(): void {
+		add_filter( 'nav_menu_item_id', function ( $menu_id, $item, $args, $depth ) {
+			return $this->container->get( Menu_Attribute_Filters::class )->customize_nav_item_id( $menu_id, $item, $args, $depth );
+		}, 10, 4 );
+
+		add_filter( 'nav_menu_css_class', function ( $classes, $item, $args, $depth ) {
+			return $this->container->get( Menu_Attribute_Filters::class )->customize_nav_item_classes( $classes, $item, $args, $depth );
+		}, 10, 4 );
+
+		add_filter( 'nav_menu_link_attributes', function ( $atts, $item, $args, $depth ) {
+			return $this->container->get( Menu_Attribute_Filters::class )->customize_nav_item_anchor_atts( $atts, $item, $args, $depth );
+		}, 10, 4 );
+	}
+
+}

--- a/wp-content/plugins/core/src/Menus/Walkers/Walker_Menu_Primary.php
+++ b/wp-content/plugins/core/src/Menus/Walkers/Walker_Menu_Primary.php
@@ -1,0 +1,214 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Menus\Walkers;
+
+use Tribe\Libs\Utils\Markup_Utils;
+use Walker_Nav_Menu;
+
+/**
+ * Class Walker_Nav_Menu_Primary
+ *
+ * Just like \Walker_Nav_Menu, but for primary site navigation
+ *
+ * @package Tribe\Project\Nav
+ */
+class Walker_Nav_Menu_Primary extends Walker_Nav_Menu {
+
+	// Capture our parent item for a sub-menu
+	private object $current_item;
+
+	/**
+	 * Starts the list before the elements are added.
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array|\stdClass  $args   An array of wp_nav_menu() arguments.
+	 *
+	 * @see   Walker::start_lvl()
+	 *
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 *
+	 * @since 3.0.0
+	 */
+	public function start_lvl( &$output, $depth = 0, $args = [] ): void {
+
+		/*
+		 *  WP Core docs claim that $args is an array, but it comes
+		 * in as an object thanks to casting in wp_nav_menu()
+		 */
+		$args = (array) $args;
+
+		// Setup sub-menu ID
+		$id = $this->current_item->ID ? ' id="menu-item-child-' . esc_attr( $this->current_item->ID ) . '"' : '';
+
+		// Setup sub-menu classes
+		$classes = Markup_Utils::class_attribute( [
+			'c-nav-' . $args['theme_location'] . '__list-child',
+			'c-nav-' . $args['theme_location'] . '__list-child--depth-' . $depth,
+		] );
+
+		$indent  = str_repeat( "\t", $depth );
+		$output .= "\n$indent<ul$id$classes data-js=\"c-nav-child-menu\">\n";
+	}
+
+	/**
+	 * Starts the element output.
+	 *
+	 * @param string           $output Passed by reference. Used to append additional content.
+	 * @param object           $item   Menu item data object.
+	 * @param int              $depth  Depth of menu item. Used for padding.
+	 * @param array|\stdClass  $args   An array of wp_nav_menu() arguments.
+	 * @param int              $id     Current item ID.
+	 *
+	 * @see   Walker::start_el()
+	 *
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 *
+	 * @since 3.0.0
+	 * @since 4.4.0 The {@see 'nav_menu_item_args'} filter was added.
+	 */
+	public function start_el( &$output, $item, $depth = 0, $args = [], $id = 0 ): void {
+
+		// Setup our parent item
+		$this->current_item = $item;
+
+		$indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+
+		$classes = empty( $item->classes ) ? [] : (array) $item->classes;
+
+		/**
+		 * Filters the arguments for a single nav menu item.
+		 *
+		 * @param array  $args  An array of arguments.
+		 * @param object $item  Menu item data object.
+		 * @param int    $depth Depth of menu item. Used for padding.
+		 *
+		 * @since 4.4.0
+		 */
+		$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
+
+		/**
+		 * Filters the CSS class(es) applied to a menu item's list item element.
+		 *
+		 * @param array  $classes The CSS classes that are applied to the menu item's `<li>` element.
+		 * @param object $item    The current menu item.
+		 * @param array  $args    An array of wp_nav_menu() arguments.
+		 * @param int    $depth   Depth of menu item. Used for padding.
+		 *
+		 * @since 3.0.0
+		 * @since 4.1.0 The `$depth` parameter was added.
+		 */
+		$class_names = implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
+		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+
+		/**
+		 * Filters the ID applied to a menu item's list item element.
+		 *
+		 * @param string $menu_id The ID that is applied to the menu item's `<li>` element.
+		 * @param object $item    The current menu item.
+		 * @param array  $args    An array of wp_nav_menu() arguments.
+		 * @param int    $depth   Depth of menu item. Used for padding.
+		 *
+		 * @since 3.0.1
+		 * @since 4.1.0 The `$depth` parameter was added.
+		 */
+		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
+		$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+
+		$output .= $indent . '<li' . $id . $class_names . '>';
+
+		$atts           = [];
+		$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
+		$atts['target'] = ! empty( $item->target ) ? $item->target : '';
+		$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
+		$atts['href']   = ! empty( $item->url ) ? $item->url : '';
+		$atts['id']     = 'menu-item-' . $item->ID;
+
+		/**
+		 * Filters the HTML attributes applied to a menu item's anchor element.
+		 *
+		 * @param array  $atts   {
+		 *                       The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
+		 *
+		 * @type string  $title  Title attribute.
+		 * @type string  $target Target attribute.
+		 * @type string  $rel    The rel attribute.
+		 * @type string  $href   The href attribute.
+		 * }
+		 *
+		 * @param object $item   The current menu item.
+		 * @param array  $args   An array of wp_nav_menu() arguments.
+		 * @param int    $depth  Depth of menu item. Used for padding.
+		 *
+		 * @since 3.6.0
+		 * @since 4.1.0 The `$depth` parameter was added.
+		 */
+		$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+
+		$has_children = in_array( 'menu-item-has-children', $item->classes );
+
+		// don't link top-level items with children in the primary nav
+		if ( $has_children && $depth === 0 ) {
+			unset( $atts['href'] );
+			$atts['data-js']       = 'c-nav-child-menu-trigger';
+			$atts['title']         = esc_attr__( 'Toggle Sub-Menu', 'tribe' );
+			$atts['aria-expanded'] = 'false';
+			$atts['aria-haspopup'] = 'true';
+			$atts['aria-controls'] = 'menu-item-child-' . esc_attr( $this->current_item->ID ) . '"';
+		}
+
+		$attributes = '';
+
+		foreach ( $atts as $attr => $value ) {
+			if ( empty( $value ) ) {
+				continue;
+			}
+
+			$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+			$attributes .= ' ' . $attr . '="' . $value . '"';
+		}
+
+		/** This filter is documented in wp-includes/post-template.php */
+		$title = apply_filters( 'the_title', $item->title, $item->ID );
+
+		/**
+		 * Filters a menu item's title.
+		 *
+		 * @param string $title The menu item's title.
+		 * @param object $item  The current menu item.
+		 * @param array  $args  An array of wp_nav_menu() arguments.
+		 * @param int    $depth Depth of menu item. Used for padding.
+		 *
+		 * @since 4.4.0
+		 */
+		$title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
+
+		$tag_name = 'a';
+		if ( $has_children && 0 === $depth ) {
+			$tag_name = 'button';
+		}
+
+		$item_output  = $args->before; // @phpstan-ignore-line (WordPress doesn't list the $args property)
+		$item_output .= '<' . $tag_name . $attributes . '>';
+		$item_output .= $args->link_before . $title . $args->link_after; // @phpstan-ignore-line (WordPress doesn't list the $args property)
+		$item_output .= '</' . $tag_name . '>';
+		$item_output .= $args->after; // @phpstan-ignore-line (WordPress doesn't list the $args property)
+
+		/**
+		 * Filters a menu item's starting output.
+		 *
+		 * The menu item's starting output only includes `$args->before`, the opening `<a>`,
+		 * the menu item's title, the closing `</a>`, and `$args->after`. Currently, there is
+		 * no filter for modifying the opening and closing `<li>` for a menu item.
+		 *
+		 * @param string $item_output The menu item's starting HTML output.
+		 * @param object $item        Menu item data object.
+		 * @param int    $depth       Depth of menu item. Used for padding.
+		 * @param array  $args        An array of wp_nav_menu() arguments.
+		 *
+		 * @since 3.0.0
+		 */
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+	}
+
+}


### PR DESCRIPTION
## What does this do/fix?

- adds menu functionality from S1 but doesn't assume anything will touch the navigation block.
- TODO: find out if the navigation block can even be filtered
- TODO: if we can't filter the navigation block what are our other options? Can we forego the navigation block entirely and just use our own custom stuff (this may be easiest since it allows us the most customization)? Can we utilize the navigation block as-is without needing extra classes/attributes/markup (if so, what would the styling structure be? per block? global?)? We'd also need to understand the limitations of the navigation block.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-13)
