### PR TITLE
[MOOSE-16] Custom Login Screen

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,11 @@ const assetEntryPoints = () => {
 			'assets',
 			'theme.js'
 		),
+		'assets/custom-login': resolve(
+			pkg.config.coreThemeDir,
+			'assets',
+			'custom-login.pcss'
+		),
 		'assets/print': resolve(
 			pkg.config.coreThemeDir,
 			'assets',

--- a/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
@@ -4,8 +4,10 @@ namespace Tribe\Plugin\Assets;
 
 class Admin_Assets_Enqueuer extends Assets_Enqueuer {
 
-	public const ADMIN       = 'admin';
-	public const ASSETS_FILE = self::ADMIN . '.asset.php';
+	public const ADMIN             = 'admin';
+	public const ASSETS_FILE       = self::ADMIN . '.asset.php';
+	public const LOGIN             = 'custom-login';
+	public const LOGIN_ASSETS_FILE = self::LOGIN . '.asset.php';
 
 	public function register(): void {
 		$args = $this->get_asset_file_args( $this->assets_path . self::ASSETS_FILE );
@@ -22,6 +24,18 @@ class Admin_Assets_Enqueuer extends Assets_Enqueuer {
 			$args['dependencies'] ?? [],
 			$args['version'] ?? false,
 			true,
+		);
+	}
+
+	public function enqueue_login_styles(): void {
+		$args = $this->get_asset_file_args( $this->assets_path . self::LOGIN_ASSETS_FILE );
+
+		wp_enqueue_style(
+			self::LOGIN,
+			$this->assets_path_uri . self::LOGIN . '.css',
+			[],
+			$args['version'] ?? false,
+			'all',
 		);
 	}
 

--- a/wp-content/plugins/core/src/Assets/Assets_Subscriber.php
+++ b/wp-content/plugins/core/src/Assets/Assets_Subscriber.php
@@ -18,6 +18,10 @@ class Assets_Subscriber extends Abstract_Subscriber {
 		add_action( 'admin_enqueue_scripts', function (): void {
 			$this->container->get( Admin_Assets_Enqueuer::class )->register();
 		}, 10, 0 );
+
+		add_action( 'login_enqueue_scripts', function (): void {
+			$this->container->get( Admin_Assets_Enqueuer::class )->enqueue_login_styles();
+		}, 10, 0 );
 	}
 
 }

--- a/wp-content/themes/core/assets/custom-login.pcss
+++ b/wp-content/themes/core/assets/custom-login.pcss
@@ -1,7 +1,8 @@
 /* -------------------------------------------------------------------------
  *
- * Print Global CSS
+ * Login Global CSS
  *
  * ------------------------------------------------------------------------- */
 
-@import "./pcss/print.pcss";
+@import "./pcss/login/_variables.pcss";
+@import "./pcss/login/login.pcss";

--- a/wp-content/themes/core/assets/pcss/login/_variables.pcss
+++ b/wp-content/themes/core/assets/pcss/login/_variables.pcss
@@ -1,0 +1,18 @@
+/* -------------------------------------------------------------------------
+ *
+ * Admin Styles: Login Variables
+ *
+ * ------------------------------------------------------------------------- */
+
+:root {
+	--login-background-color: #f5f5f5;
+	--login-form-background-color: #fff;
+	--login-primary-color: #2271b1;
+	--login-secondary-color: #0a4b78;
+	--login-white-color: #fff;
+
+	--login-background-image: url(https://source.unsplash.com/random/960x1080/?texture,blur);
+	--login-logo-image: url(data:image/svg+xml,%3Csvg width="44" height="33" viewBox="0 0 44 33" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M8.3378 0L0.383431 31.4317L0 33H44L35.6021 0.0100784L21.9822 12.135L8.3378 0ZM9.76739 4.6473L20.1178 13.8526L3.77059 28.3429L9.76739 4.6473ZM23.8822 13.8212L34.1782 4.65514L40.1918 28.2788L23.8822 13.8212ZM22.0175 15.5396L38.8734 30.4804H5.16173L22.0175 15.5396Z" fill="black"%3E%3C/path%3E%3C/svg%3E);
+	--login-logo-width: 150px;
+	--login-logo-height: 113px;
+}

--- a/wp-content/themes/core/assets/pcss/login/login.pcss
+++ b/wp-content/themes/core/assets/pcss/login/login.pcss
@@ -1,0 +1,171 @@
+/* -------------------------------------------------------------------------
+ *
+ * Admin Styles: Login
+ *
+ * ------------------------------------------------------------------------- */
+
+/* -----------------------------------------------------------------------
+ * Login: Body Element
+ * ----------------------------------------------------------------------- */
+
+.login {
+	height: 100%;
+	position: relative;
+	width: 100%;
+	display: table;
+	background: var(--login-background-color);
+}
+
+.login::after {
+	content: "";
+	display: none;
+	width: 50%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	right: 0;
+	background: var(--login-background-image) center no-repeat;
+	background-size: cover;
+
+	@media (min-width: 960px) {
+		display: block;
+	}
+}
+
+/* -----------------------------------------------------------------------
+ * Login: Button Focus Styling
+ * ----------------------------------------------------------------------- */
+
+.login a,
+.login button,
+.login input[type="submit"] {
+
+	&:focus,
+	&:active {
+		box-shadow: none;
+		outline: 1px dotted;
+	}
+}
+
+/* -----------------------------------------------------------------------
+ * Login: Login Form Wrapper
+ * ----------------------------------------------------------------------- */
+
+.login #login {
+	overflow: hidden;
+	position: relative;
+	z-index: 1;
+	padding: 80px 25px 100px;
+	display: table-cell;
+	width: 100%;
+	vertical-align: middle;
+
+	& > * {
+		max-width: 425px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media (min-width: 960px) {
+		width: 50%;
+	}
+}
+
+/* -----------------------------------------------------------------------
+ * Login: Primary Log In Button
+ * ----------------------------------------------------------------------- */
+
+.login.wp-core-ui .button-primary {
+	background: var(--login-primary-color);
+	color: var(--login-white-color);
+	border: 0;
+	box-shadow: none;
+	display: block;
+	width: 100%;
+	padding: 10px;
+	margin: 15px auto 0;
+	font-size: 16px;
+	height: auto;
+	float: none;
+	text-shadow: none;
+
+	&:hover,
+	&:focus,
+	&:active {
+		background: var(--login-secondary-color);
+	}
+}
+
+/* -----------------------------------------------------------------------
+ * Login: Login Form
+ * ----------------------------------------------------------------------- */
+
+.login form {
+	margin: 8px auto 10px;
+	padding: 20px 24px 24px;
+	backface-visibility: hidden;
+	position: relative !important;
+	background-color: var(--login-form-background-color);
+
+	.forgetmenot {
+		float: none;
+	}
+
+	.submit {
+		float: none;
+		clear: both;
+		display: block;
+	}
+}
+
+/* -----------------------------------------------------------------------
+ * Login: Logo
+ * ----------------------------------------------------------------------- */
+
+.login h1 {
+	padding: 8px;
+	margin: 0 auto 16px;
+}
+
+.login h1 a {
+	width: var(--login-logo-width);
+	height: var(--login-logo-height);
+	line-height: 1;
+	margin: 0 auto;
+	background: var(--login-logo-image) center no-repeat;
+	background-size: contain;
+}
+
+/* -----------------------------------------------------------------------
+ * Login: Utility Links
+ * ----------------------------------------------------------------------- */
+
+.login #nav,
+.login #backtoblog {
+	padding: 3px 2px;
+	margin: 0 auto;
+	text-align: center;
+	font-size: 15px;
+}
+
+.login #nav a,
+.login #backtoblock a {
+	padding: 3px 0;
+	margin: 0 auto;
+	text-align: center;
+	color: var(--login-primary-color);
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: var(--login-secondary-color);
+	}
+}
+
+.login #nav {
+	margin-top: 15px;
+}
+
+.login #backtoblog {
+	margin-top: 8px;
+}


### PR DESCRIPTION
## What does this do/fix?

- ports over Square One styling for the login screen
- creates new entry point for the new login styles (we don't need anything else from the admin or theme, so it's okay that it's its own thing)
- enqueues the new login styles
- updates the login screen to include a 50/50 layout on small to large desktops with a random "texture" image from unsplash
- modernizes the styling so that we only have to change CSS properties (located in `assets/pcss/login/_variables.pcss`) to change the entire login screen
- currently the logo is setup as a encoded SVG - this can be changed to a SVG located in your theme if necessary
- logo width/height are also available as CSS properties in the same spot
- adds a comment to the main print entry point (was missed previously)

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-16)

Screenshots/video:
- http://p.tri.be/i/trnWEK
