### PR TITLE
[MOOSE-40]: Upgrade to WordPress core 6.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 			"@php -r \"file_exists('local-config.php') || copy('local-config-sample.php', 'local-config.php');\"",
 			"@php -r \"file_exists('local-config.json') || copy('local-config-sample.json', 'local-config.json');\""
 		],
-		"setup-wordpress": "./vendor/bin/wp core download --version=6.2 --quiet --skip-content --force",
+		"setup-wordpress": "./vendor/bin/wp core download --version=6.2.2 --quiet --skip-content --force",
 		"post-root-package-install": [
 			"@setup-repo"
 		],


### PR DESCRIPTION
## What does this do/fix?

Updates WP Core to 6.2.2

