### PR TITLE
[TRY] Intersection Observer Animation

### DIFF
--- a/wp-content/themes/core/assets/js/theme/ready.js
+++ b/wp-content/themes/core/assets/js/theme/ready.js
@@ -6,6 +6,7 @@
 
 import { ready } from 'utils/events.js';
 import { debounce } from 'utils/tools.js';
+import animateOnScroll from 'utils/animate-on-scroll.js';
 
 import resize from 'common/resize.js';
 import viewportDims from 'common/viewport-dims.js';
@@ -32,6 +33,10 @@ const init = () => {
 	// initialize global events
 
 	bindEvents();
+
+	// initialize on scroll animations
+
+	animateOnScroll();
 
 	console.info(
 		'Moose Theme: Initialized all javascript that targeted document ready.'

--- a/wp-content/themes/core/assets/js/utils/animate-on-scroll.js
+++ b/wp-content/themes/core/assets/js/utils/animate-on-scroll.js
@@ -1,0 +1,79 @@
+/**
+ * @module
+ * @exports init
+ * @description functions for handling elements that should change on scroll
+ */
+
+const el = {};
+
+/**
+ * @function handleIntersection
+ *
+ * @description Callback function for when an element comes into view
+ *
+ * @param {*} entries
+ */
+const handleIntersection = ( entries ) => {
+	entries.forEach( ( entry ) => {
+		if ( entry.isIntersecting ) {
+			entry.target.classList.remove( 'is-exiting-view' );
+			entry.target.classList.add( 'is-scrolled-into-view' );
+			entry.target.classList.add( 'is-scrolled-into-view-first-time' );
+		} else {
+			entry.target.classList.remove( 'is-scrolled-into-view' );
+			entry.target.classList.add( 'is-exiting-view' );
+		}
+	} );
+};
+
+/**
+ * @function attachObservers
+ *
+ * @description attach intersection observers to elements
+ */
+const attachObservers = () => {
+	if ( el.aosElements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 0.25,
+		} );
+
+		el.aosElements.forEach( ( element ) => observer.observe( element ) );
+	}
+
+	if ( el.aosFullElements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 1,
+		} );
+
+		el.aosFullElements.forEach( ( element ) =>
+			observer.observe( element )
+		);
+	}
+};
+
+/**
+ * @function cacheElements
+ *
+ * @description Cache elements for this module
+ */
+const cacheElements = () => {
+	// grabs elements that should animate when the element is 25% in view
+	el.aosElements = document.querySelectorAll( '.is-animated-on-scroll' );
+
+	// grabs elements that should animate when the entire element is in view
+	el.aosFullElements = document.querySelectorAll(
+		'.is-animated-on-scroll-full'
+	);
+};
+
+/**
+ * @function init
+ *
+ * @description Kick off this module's functionality
+ */
+const init = () => {
+	cacheElements();
+	attachObservers();
+};
+
+export default init;


### PR DESCRIPTION
## What does this do/fix?

I tried to use `is-{state}` class names for this feature as this seems like the WordPress approach to state classes. If we feel like these class names don't fit I can try something else.

- defines a new JS util for handling setting classes for elements that should animate on scroll
- uses two classes to trigger the functionality: `is-animated-on-scroll` and `is-animated-on-scroll-full`. 
- `is-animated-on-scroll` handles the functionality when the element is 25% in or out of view
- `is-animated-on-scroll-full` handles the functionality when the element is fully in view
- if an element is in view for the first time the element will get a `is-scrolled-into-view-first-time` class. This allows us to set animations on an element one time for a page load.
- If an element is intersecting it will get the `is-scrolled-into-view` class. If it is not intersecting this class will be removed.
- If an element is outside of the intersection it will receive an `is-exiting-view` class. This class can be used for exit animations.

## QA

Screenshots/video:
- [Demo Video](http://p.tri.be/v/k3lrLb)
