### PR TITLE
[MOOSE-26]: Adds the ability to hide the ACF menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2023.06]
+
+- Added: Ability to hide ACF menu item using the `HIDE_ACF_MENU` constant (boolean true hides the menu item) or if we are in a production environment.
+
 ## [2023.05]
 
 - Security: Removed default support for XML-RCP Authentication.

--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -48,3 +48,12 @@ if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
  * If you would like to disable the plugin locally, add the following to your local-config.php.
  */
 define( 'TRIBE_GLOMAR', false );
+
+/*
+ * ACF Integration
+ *
+ * If the constant is set to true, this will hide the ACF menu item.  The ACF
+ * menu item is also hidden when wp_get_environment_type() function returns
+ * 'production'.
+ */
+define( 'HIDE_ACF_MENU', false );

--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -3,8 +3,6 @@
 namespace Tribe\Plugin;
 
 use DI\ContainerBuilder;
-use Tribe\Libs\Settings\Settings_Definer;
-use Tribe\Libs\Settings\Settings_Subscriber;
 
 class Core {
 
@@ -19,20 +17,21 @@ class Core {
 	 * @var string[] Names of classes implementing Definer_Interface.
 	 */
 	private array $definers = [
+		\Tribe\Libs\Settings\Settings_Definer::class,
 		Blocks\Blocks_Definer::class,
 		Object_Meta\Meta_Definer::class,
 		Settings\Settings_Definer::class,
-		Settings_Definer::class,
 	];
 
 	/**
 	 * @var string[] Names of classes extending Abstract_Subscriber.
 	 */
 	private array $subscribers = [
+		\Tribe\Libs\Settings\Settings_Subscriber::class,
 		Assets\Assets_Subscriber::class,
 		Blocks\Blocks_Subscriber::class,
+		Integrations\Integrations_Subscriber::class,
 		Object_Meta\Meta_Subscriber::class,
-		Settings_Subscriber::class,
 		Theme_Config\Theme_Config_Subscriber::class,
 	];
 

--- a/wp-content/plugins/core/src/Integrations/ACF.php
+++ b/wp-content/plugins/core/src/Integrations/ACF.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Integrations;
+
+class ACF {
+
+	/**
+	 * Hides the ACF "Custom Fields" Menu item if the HIDE_ACF_MENU constant is
+	 * set to true or if we are in a production environment based on the
+	 * wp_get_environment_type() function.
+	 *
+	 * @param bool $show_menu_item
+	 */
+	public function show_acf_menu_item( bool $show_menu_item ): bool {
+
+		if ( defined( 'HIDE_ACF_MENU' ) && HIDE_ACF_MENU === true ) {
+			return false;
+		}
+
+		if ( wp_get_environment_type() === 'production' ) {
+			return false;
+		}
+
+		return $show_menu_item;
+	}
+
+}

--- a/wp-content/plugins/core/src/Integrations/ACF.php
+++ b/wp-content/plugins/core/src/Integrations/ACF.php
@@ -5,8 +5,8 @@ namespace Tribe\Plugin\Integrations;
 class ACF {
 
 	/**
-	 * Hides the ACF "Custom Fields" Menu item if the HIDE_ACF_MENU constant is
-	 * set to true or if we are in a production environment based on the
+	 * Hides the ACF Menu item if the HIDE_ACF_MENU constant isset to true or
+	 * if we are in a production environment based on the
 	 * wp_get_environment_type() function.
 	 *
 	 * @param bool $show_menu_item

--- a/wp-content/plugins/core/src/Integrations/Integrations_Subscriber.php
+++ b/wp-content/plugins/core/src/Integrations/Integrations_Subscriber.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Integrations;
+
+use Tribe\Libs\Container\Abstract_Subscriber;
+use Tribe\Plugin\Integrations\ACF;
+
+class Integrations_Subscriber extends Abstract_Subscriber {
+
+	public function register(): void {
+
+		add_filter( 'acf/settings/show_admin', function ( $show ): bool {
+			return $this->container->get( ACF::class )->show_acf_menu_item( (bool) $show );
+		}, 10, 1 );
+	}
+
+}


### PR DESCRIPTION
## What does this do/fix?

Adds the ability to hide the ACF menu item using the `HIDE_ACF_MENU` constant. This update also always hides the menu item if `wp_get_environment_type()` returns `'production'`. 

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-26)

Screenshots/video:
- [Link to Video](http://p.tri.be/i/SssxOI)
