### PR TITLE
Misc Fixes

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -59,6 +59,7 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 		add_action( 'admin_enqueue_scripts', function (): void {
 			// Register block admin scripts
 			foreach ( $this->container->get( Blocks_Definer::EXTENDED ) as $block ) {
+				$block->register_style();
 				$block->register_admin_scripts();
 				$block->enqueue_admin_scripts();
 			}

--- a/wp-content/themes/core/assets/pcss/layout/default.pcss
+++ b/wp-content/themes/core/assets/pcss/layout/default.pcss
@@ -43,3 +43,14 @@
 :is(.editor-styles-wrapper) .has-global-padding :is(.has-global-padding) > .alignwide {
 	max-width: var(--wp--style--global--wide-size);
 }
+
+/*
+ * Previously to this change, adding a full width pattern to the bottom
+ * of a page would force the user to have to use "Insert After" functions
+ * to add a block below.
+ * This adds space for clicking at the bottom of the
+ * .editor-styles-wrapper element and only appears in the admin editor.
+ */
+:is(.editor-styles-wrapper) {
+	padding-bottom: 40vh;
+}

--- a/wp-content/themes/core/assets/pcss/media/_mixins.pcss
+++ b/wp-content/themes/core/assets/pcss/media/_mixins.pcss
@@ -15,7 +15,7 @@
 			max-width: 220px;
 		}
 
-		/* Fill available space left/right of contentSize block */
+		/* Ensure media can only obtain a max-width of 100% of the container */
 		@media (--viewport-large) {
 			max-width: 100%;
 		}

--- a/wp-content/themes/core/assets/pcss/media/_mixins.pcss
+++ b/wp-content/themes/core/assets/pcss/media/_mixins.pcss
@@ -17,7 +17,7 @@
 
 		/* Fill available space left/right of contentSize block */
 		@media (--viewport-large) {
-			max-width: calc(((100% - var(--wp--style--global--content-size)) / 2) - 2em);
+			max-width: 100%;
 		}
 	}
 

--- a/wp-content/themes/core/blocks/core/button/admin.js
+++ b/wp-content/themes/core/blocks/core/button/admin.js
@@ -1,0 +1,11 @@
+/**
+ * Admin scripts specific to this block
+ */
+
+import { ready } from 'utils/events.js';
+import { unregisterBlockStyle } from '@wordpress/blocks';
+
+ready( () => {
+	unregisterBlockStyle( 'core/button', 'default' );
+	unregisterBlockStyle( 'core/button', 'outline' );
+} );

--- a/wp-content/themes/core/blocks/core/button/editor.pcss
+++ b/wp-content/themes/core/blocks/core/button/editor.pcss
@@ -1,7 +1,0 @@
-/**
- * Editor-specific styles for this block.
- */
-
-.wp-block-button {
-	outline: 2px solid #0f0;
-}

--- a/wp-content/themes/core/blocks/core/button/index.js
+++ b/wp-content/themes/core/blocks/core/button/index.js
@@ -3,4 +3,3 @@
  */
 
 import './style.pcss';
-import './editor.pcss';

--- a/wp-content/themes/core/blocks/core/lists/Lists.php
+++ b/wp-content/themes/core/blocks/core/lists/Lists.php
@@ -7,6 +7,10 @@ use Tribe\Plugin\Blocks\Block_Base;
 class Lists extends Block_Base {
 
 	public function get_block_name(): string {
+		return 'core/list';
+	}
+
+	public function get_block_path(): string {
 		return 'core/lists';
 	}
 


### PR DESCRIPTION
## What does this do/fix?

- fixes issue with core block styles not enqueuing in the admin
- fixes issue with full-width blocks blocking editors from being able to easily add blocks to the bottom of the editor window just by clicking (just add some space to the bottom of `.editor-styles-wrapper`).
- fixes issue with floated images essentially disappearing from content if using the "content size" width
- unregistered some styles from the core button block
- removes admin styles from the core button block (easy enough to add back in and we moved away from having admin files for core blocks that didn't need them)
- fixes list styles not properly pulling in because of the difference in the core block name/slug.
