### PR TITLE
[FIX] Rename admin styles / scripts to `tribe-admin` to avoid reserved words

### DIFF
--- a/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
@@ -6,8 +6,9 @@ use Tribe\Plugin\Settings\Login_Settings;
 
 class Admin_Assets_Enqueuer extends Assets_Enqueuer {
 
-	public const ADMIN             = 'admin';
-	public const ASSETS_FILE       = self::ADMIN . '.asset.php';
+	public const ADMIN             = 'tribe-admin';
+	public const ADMIN_FILE_NAME   = 'admin';
+	public const ASSETS_FILE       = self::ADMIN_FILE_NAME . '.asset.php';
 	public const LOGIN             = 'tribe-login';
 	public const LOGIN_FILE_NAME   = 'login';
 	public const LOGIN_ASSETS_FILE = self::LOGIN_FILE_NAME . '.asset.php';

--- a/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
@@ -17,14 +17,14 @@ class Admin_Assets_Enqueuer extends Assets_Enqueuer {
 		$args = $this->get_asset_file_args( $this->assets_path . self::ASSETS_FILE );
 		wp_enqueue_style(
 			self::ADMIN,
-			$this->assets_path_uri . self::ADMIN . '.css',
+			$this->assets_path_uri . self::ADMIN_FILE_NAME . '.css',
 			[],
 			$args['version'] ?? false,
 			'all',
 		);
 		wp_enqueue_script(
 			self::ADMIN,
-			$this->assets_path_uri . self::ADMIN . '.js',
+			$this->assets_path_uri . self::ADMIN_FILE_NAME . '.js',
 			$args['dependencies'] ?? [],
 			$args['version'] ?? false,
 			true,


### PR DESCRIPTION
## What does this do/fix?

- renames `admin` admin scripts to `tribe-admin` to avoid reserved word declarations. I think we fixed this on QCHI but it must not have made it's way back over to Moose. I'll be updating this on Careforth as well.

## QA

Links to relevant issues
- Found on Careforth in the styleguide ticket: https://moderntribe.atlassian.net/browse/SNRLNK-88
