### PR TITLE
[MOOSE-37] 404 template

### DIFF
--- a/wp-content/themes/core/templates/404.html
+++ b/wp-content/themes/core/templates/404.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"top":"0"}}}} -->
+<h1 class="wp-block-heading has-text-align-center" style="margin-top:0">404 Error</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","className":"is-style-large"} -->
+<p class="has-text-align-center is-style-large">Sorry, this page couldn't be found.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
## What does this do/fix?

- adds a simple 404 page template
- 404 page template can be edited by the client under Appearance > Editor > Templates > 404
- our template should only be used as a starting point. We can update the template in code if we feel strong enough about saving an updated version of the 404 as the "default" but it's easy enough to update across environments that I don't think it's such a big deal. 

## QA

Links to relevant issues
- [MOOSE-37](https://moderntribe.atlassian.net/browse/MOOSE-37)

Screenshots/video:
- [Screenshot](http://p.tri.be/i/JZSTrq)


[MOOSE-37]: https://moderntribe.atlassian.net/browse/MOOSE-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ