### PR TITLE
Update layout style rule comments 

### DIFF
--- a/wp-content/themes/core/assets/pcss/layout/default.pcss
+++ b/wp-content/themes/core/assets/pcss/layout/default.pcss
@@ -13,6 +13,8 @@
  * ------------------------------------------------------------------------- */
 
 /*
+ * CASE: settings.layout.wideSize = fluid value
+ *
  * Max-width of blocks aligned wide should not account for grid margin
  * when nested in .has-global-padding because the container applies
  * grid margin as padding.
@@ -29,6 +31,8 @@
 }
 
 /*
+ * CASE: settings.layout.wideSize = fluid value
+ *
  * Max-width of blocks aligned wide nested inside two .has-global-padding
  * containers need to re-account for grid-margin.
  *


### PR DESCRIPTION
## What does this do/fix?

Ran into an issue on Careforth where it wasn't clear that the layout style rules are needed only when `settings.layout.wideSize` is a fluid value, not fixed.

Moose has a fluid value for wideSize, so it makes sense to keep the rules. I've updated the comments so it's more clear they can be removed if it's a static value.

## QA

Screenshots/video:
- [Link to Screencast overview](http://p.tri.be/v/yh3QcA)
