### PR TITLE
[MOOSE-47] Post Permalink Custom Block

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -31,6 +31,7 @@ class Blocks_Definer implements Definer_Interface {
 		return [
 			self::TYPES           => DI\add( [
 				'tribe/post-type-name',
+				'tribe/post-permalink',
 			] ),
 
 			self::EXTENDED        => DI\add( [

--- a/wp-content/themes/core/assets/pcss/typography/_mixins.pcss
+++ b/wp-content/themes/core/assets/pcss/typography/_mixins.pcss
@@ -118,3 +118,15 @@
 	text-transform: uppercase;
 	text-decoration: none;
 }
+
+/* -------------------------------------------------------------------------
+ * Caption
+ * Defined in theme.json but used in other places (post permalink block)
+ * ------------------------------------------------------------------------- */
+
+@define-mixin t-caption {
+	font-family: var(--wp--preset--font-family--roboto);
+	font-size: var(--wp--preset--font-size--10);
+	line-height: 1.6;
+	font-weight: 400;
+}

--- a/wp-content/themes/core/blocks/tribe/post-permalink/block.json
+++ b/wp-content/themes/core/blocks/tribe/post-permalink/block.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "tribe/post-type-name",
+	"name": "tribe/post-permalink",
 	"version": "0.1.0",
-	"title": "Post Type Name",
+	"title": "Post Permalink",
 	"category": "text",
-	"icon": "edit-large",
-	"description": "Returns the post type name for a post object.",
+	"icon": "admin-links",
+	"description": "Returns the post permalink as link text.",
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/wp-content/themes/core/blocks/tribe/post-permalink/edit.js
+++ b/wp-content/themes/core/blocks/tribe/post-permalink/edit.js
@@ -1,0 +1,32 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Server-side rendering of the block in the editor view
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-server-side-render/
+ */
+import ServerSideRender from '@wordpress/server-side-render';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender block="tribe/post-permalink" />
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/post-permalink/index.js
+++ b/wp-content/themes/core/blocks/tribe/post-permalink/index.js
@@ -1,0 +1,33 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.pcss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/wp-content/themes/core/blocks/tribe/post-permalink/render.php
+++ b/wp-content/themes/core/blocks/tribe/post-permalink/render.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+$post_permalink = get_the_permalink();
+?>
+
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<span class="wp-block-tribe-post-permalink__label"><?php esc_html_e( $post_permalink, 'tribe' ); ?></span>
+</div>

--- a/wp-content/themes/core/blocks/tribe/post-permalink/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/post-permalink/style.pcss
@@ -1,0 +1,12 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-tribe-post-permalink {
+
+	@mixin t-caption;
+	color: var(--color-neutral-60);
+}

--- a/wp-content/themes/core/patterns/card-post-search-result.php
+++ b/wp-content/themes/core/patterns/card-post-search-result.php
@@ -15,9 +15,13 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"0","bottom":"var:preset|spacing|40","left":"0"}}},"className":"p-card-search-result l-clearfix","layout":{"type":"default"}} -->
 <div class="wp-block-group p-card-search-result l-clearfix" style="padding-top:var(--wp--preset--spacing--40);padding-right:0;padding-bottom:var(--wp--preset--spacing--40);padding-left:0"><!-- wp:post-featured-image {"width":"22%","align":"right","className":"p-card-search-result__image s-aspect-ratio-cover s-aspect-ratio-4-3"} /-->
 
+<!-- wp:tribe/post-type-name {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} /-->
+
 <!-- wp:post-title {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}},"className":"p-card-search-result__title","fontSize":"60"} /-->
 
 <!-- wp:post-excerpt /-->
+
+<!-- wp:tribe/post-permalink {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20","right":"0","bottom":"0","left":"0"}}}} /-->
 
 <!-- wp:post-title {"isLink":true,"className":"a-hidden-link-cover"} /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
## What does this do/fix?

**NOTE: [This PR](https://github.com/moderntribe/moose/pull/61) & [this PR](https://github.com/moderntribe/moose/pull/63) should be reviewed before this one. This one adds on top of them.**

- adds Post Permalink custom block that displays the post permalink as text. Possible we should add `aria-hidden` here so it's not read?
- updates Post Type Name block with support for margin/padding
- updates Search Result Post Card pattern with the two new blocks

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-47)

Screenshots/video:
- FE Screenshot: http://p.tri.be/i/7Pbs5i
- BE Screenshot: http://p.tri.be/i/nmyOwz
