### PR TITLE
[MOOSE-48] Query Results Count Block

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -32,6 +32,7 @@ class Blocks_Definer implements Definer_Interface {
 			self::TYPES           => DI\add( [
 				'tribe/post-type-name',
 				'tribe/post-permalink',
+				'tribe/query-results-count',
 			] ),
 
 			self::EXTENDED        => DI\add( [

--- a/wp-content/themes/core/blocks/tribe/query-results-count/block.json
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "tribe/query-results-count",
+	"version": "0.1.0",
+	"title": "Query Results Count",
+	"category": "text",
+	"icon": "chart-line",
+	"description": "Displays (in context) the total number of posts in a archive",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/wp-content/themes/core/blocks/tribe/query-results-count/edit.js
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/edit.js
@@ -1,0 +1,32 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Server-side rendering of the block in the editor view
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-server-side-render/
+ */
+import ServerSideRender from '@wordpress/server-side-render';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender block="tribe/query-results-count" />
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/query-results-count/index.js
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/index.js
@@ -1,0 +1,33 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.pcss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/wp-content/themes/core/blocks/tribe/query-results-count/render.php
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/render.php
@@ -1,16 +1,21 @@
 <?php declare(strict_types=1);
 
 global $wp_query;
-$output     = '';
-$is_search  = is_search();
-$post_count = (int) $wp_query->post_count;
+$is_search = is_search();
+$count     = (int) $wp_query->post_count;
+$output    = sprintf( _n( '%d result', '%d results', $count, 'tribe' ), number_format_i18n( $count ) );
 
 if ( $is_search ) {
-	$output = $post_count !== 1
-				? $post_count . ' results for <span class="search-term">"'. get_search_query() .'"</span>'
-				: '1 result for <span class="search-term">"'. get_search_query() .'"</span>';
-} else {
-	$output = "$wp_query->post_count results";
+	$output = sprintf(
+		_x(
+			'%s %s for <span class="search-term">&ldquo;%s&rdquo;</span>',
+			'First value is the number of results, second is word "result" (pluralized if necessary), third is the search term',
+			'tribe'
+		),
+		number_format_i18n( $count ),
+		_n( 'result', 'results', $count, 'tribe' ),
+		get_search_query()
+	);
 }
 ?>
 

--- a/wp-content/themes/core/blocks/tribe/query-results-count/render.php
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/render.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+global $wp_query;
+$output     = '';
+$is_search  = is_search();
+$post_count = (int) $wp_query->post_count;
+
+if ( $is_search ) {
+	$output = $post_count !== 1
+				? $post_count . ' results for <span class="search-term">"'. get_search_query() .'"</span>'
+				: '1 result for <span class="search-term">"'. get_search_query() .'"</span>';
+} else {
+	$output = "$wp_query->post_count results";
+}
+?>
+
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<p><?php echo wp_kses_post( $output ); ?></p>
+</div>

--- a/wp-content/themes/core/blocks/tribe/query-results-count/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/style.pcss
@@ -1,0 +1,15 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-tribe-query-results-count {
+
+	@mixin t-body;
+
+	.search-term {
+		font-weight: 700;
+	}
+}

--- a/wp-content/themes/core/templates/search.html
+++ b/wp-content/themes/core/templates/search.html
@@ -8,19 +8,23 @@
 <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /--></div>
 <!-- /wp:group -->
 
+<!-- wp:tribe/query-results-count {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} /-->
+
 <!-- wp:query {"queryId":0,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"list"},"align":"wide"} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template -->
-<!-- wp:columns {"verticalAlignment":"top","className":"p-search-card"} -->
-<div class="wp-block-columns are-vertically-aligned-top p-search-card"><!-- wp:column {"verticalAlignment":"top","width":"%"} -->
-<div class="wp-block-column is-vertically-aligned-top"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}}} /-->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"0","bottom":"var:preset|spacing|40","left":"0"}}},"className":"p-card-search-result l-clearfix","layout":{"type":"default"}} -->
+<div class="wp-block-group p-card-search-result l-clearfix" style="padding-top:var(--wp--preset--spacing--40);padding-right:0;padding-bottom:var(--wp--preset--spacing--40);padding-left:0"><!-- wp:post-featured-image {"width":"22%","align":"right","className":"p-card-search-result__image s-aspect-ratio-cover s-aspect-ratio-4-3"} /-->
 
-<!-- wp:post-excerpt /--></div>
-<!-- /wp:column -->
+<!-- wp:tribe/post-type-name {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} /-->
 
-<!-- wp:column {"verticalAlignment":"top","width":"248px"} -->
-<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:248px"><!-- wp:post-featured-image /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
+<!-- wp:post-title {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}},"className":"p-card-search-result__title","fontSize":"60"} /-->
+
+<!-- wp:post-excerpt /-->
+
+<!-- wp:tribe/post-permalink {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20","right":"0","bottom":"0","left":"0"}}}} /-->
+
+<!-- wp:post-title {"isLink":true,"className":"a-hidden-link-cover"} /--></div>
+<!-- /wp:group -->
 <!-- /wp:post-template -->
 
 <!-- wp:query-no-results -->


### PR DESCRIPTION
## What does this do/fix?

**NOTE: This PR is dependent on 3 other PRs: [Post Card Patterns](https://github.com/moderntribe/moose/pull/61), [Post Type Name Custom Block](https://github.com/moderntribe/moose/pull/63), [Post Permalink Custom Block](https://github.com/moderntribe/moose/pull/64).**

- adds Query Results Count Block
    - only works on archives / search templates. It doesn't seem possible to get query block contexts in inner blocks. This may be what Justin was mentioned on QCHI at one point. 
    - if on the Search page, will check for the search query and append that onto the results count.
    - otherwise, will just display "x results" (this can be easily updated) 
    - seems to always display "0 results" in the editor (likely because we don't have the `$wp_query` context)
- updates Search Results template with new Search Results Posts patterns & Query Results Count Block

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-48)

Screenshots/video:
- FE screenshot: http://p.tri.be/i/nmyOwz
- Editor screenshot: http://p.tri.be/i/u48i4E
