### PR TITLE
[MOOSE-52] Filter Post Terms Block by Classes

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -5,6 +5,7 @@ namespace Tribe\Plugin\Blocks;
 use DI;
 use Tribe\Libs\Container\Definer_Interface;
 use Tribe\Plugin\Blocks\Filters\Contracts\Filter_Factory;
+use Tribe\Plugin\Blocks\Filters\Post_Terms_Filter;
 use Tribe\Theme\blocks\core\button\Button;
 use Tribe\Theme\blocks\core\embed\Embed;
 use Tribe\Theme\blocks\core\heading\Heading;
@@ -53,6 +54,7 @@ class Blocks_Definer implements Definer_Interface {
 			] ),
 
 			self::FILTERS         => DI\add( [
+				DI\get( Post_Terms_Filter::class ),
 			] ),
 
 			Filter_Factory::class => DI\autowire()->constructorParameter( 'filters', DI\get( self::FILTERS ) ),

--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -37,7 +37,7 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 		add_filter( 'render_block', function ( string $block_content, array $block ): string {
 			$filter = $this->container->get( Filter_Factory::class )->make( $block );
 
-			return $filter ? $filter->filter_block_content( $block_content ) : $block_content;
+			return $filter ? $filter->filter_block_content( $block_content, $block ) : $block_content;
 		}, 10, 2 );
 
 		add_action( 'after_setup_theme', function (): void {

--- a/wp-content/plugins/core/src/Blocks/Filters/Contracts/Block_Content_Filter.php
+++ b/wp-content/plugins/core/src/Blocks/Filters/Contracts/Block_Content_Filter.php
@@ -6,6 +6,6 @@ abstract class Block_Content_Filter {
 
 	public const BLOCK = '';
 
-	abstract public function filter_block_content( string $block_content ): string;
+	abstract public function filter_block_content( string $block_content, array $block ): string;
 
 }

--- a/wp-content/plugins/core/src/Blocks/Filters/Post_Terms_Filter.php
+++ b/wp-content/plugins/core/src/Blocks/Filters/Post_Terms_Filter.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Blocks\Filters;
+
+use Tribe\Plugin\Blocks\Filters\Contracts\Block_Content_Filter;
+
+class Post_Terms_Filter extends Block_Content_Filter {
+
+	public const BLOCK = 'core/post-terms';
+
+	public function filter_block_content( string $block_content, array $block ): string {
+		// if we don't have any filter classes (or classes at all), return early
+		if ( ! array_key_exists( 'className', $block['attrs'] ) ) {
+			return $block_content;
+		}
+
+		// determine what we should be filtering
+		$should_remove_links      = str_contains( $block['attrs']['className'], 'filter-remove-links' );
+		$should_remove_separators = str_contains( $block['attrs']['className'], 'filter-remove-separators' );
+		$should_display_one_term  = str_contains( $block['attrs']['className'], 'filter-display-one-term' );
+
+		// setup output variable
+		$output = '';
+
+		// remove all content between the block wrapper
+		$wrapper = preg_replace( '#(<div[^>]*>).*?(</div>)#', '$1$2', $block_content );
+
+		// split the wrapper so we can reassemble it later
+		$explode_wrapper = explode( '><', $wrapper );
+
+		// setup the start of the wrapper
+		$wrapper_start = $explode_wrapper[0] . '>';
+
+		// setup the end of the wrapper
+		$wrapper_end = '<' . $explode_wrapper[1];
+
+		// remove the start & end wrapper from the block content (so we're only left with the contents)
+		$removed_wrapper = str_replace( $wrapper_start, '', str_replace( $wrapper_end, '', $block_content ) );
+
+		// determine what we should split the contents by (separator)
+		$explode_by = $block['attrs']['separator'] !== '' ? $block['attrs']['separator'] : ' ';
+
+		// setup a separator variable so we can easily use it later
+		$separator = sprintf( '<span class="wp-block-post-terms__separator">%s</span>', $explode_by );
+
+		// change the contents into an array of items
+		$explode = explode( $separator, $removed_wrapper );
+
+		// rebuild block content
+
+		// start with the wrapper
+		$output .= $wrapper_start;
+
+		// determine if we should display one term or all of them
+		if ( $should_display_one_term ) {
+			// if we should remove links, strip all tags from the item
+			// if we're displaying one term, we don't have to worry abouot separators
+			$output .= $should_remove_links
+				? sprintf(
+					'<span class="%s">%s</span>',
+					esc_attr( 'wp-block-post-terms__term' ),
+					strip_tags( $explode[0] )
+				)
+				: sprintf( '%s', $explode[0] );
+		} else {
+			// if we should show all terms, loop through them
+			// if we should remove links, strip all tags from the item
+			// if we should show separators, don't show the last one
+			foreach ( $explode as $key => $item ) {
+				$output .= $should_remove_links
+					? sprintf(
+						'<span class="%s">%s</span>%s',
+						esc_attr( 'wp-block-post-terms__term' ),
+						strip_tags( $item ),
+						$should_remove_separators ? '' : ( $key + 1 < count( $explode ) ? $separator : '' )
+					)
+					: sprintf( '%s%s', $item, $should_remove_separators ? '' : $separator );
+			}
+		}
+
+		// end with the wrapper
+		// phpcs:ignore
+		$output .= $wrapper_end;
+
+		// return the new output
+		return $output;
+	}
+
+}

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -69,7 +69,7 @@ picture {
  * currently be breaking, maybe something to keep an eye on.
  * @see https://github.com/wpcomvip/careforth/pull/14
  */
-iframe
+iframe,
 video,
 embed {
 	max-width: 100%;


### PR DESCRIPTION
## What does this do/fix?

**NOTE: I am fully aware this code _sucks_. I wanted to take a stab at using the block content filter we have built into Moose (we used on M12, but haven't since then) in order to create a system for this block where we can create different version of the block via classes set on the block. I would probably want BE to take a pass at the function to see if they can clean it up.** 

- `filter-remove-links` removes the links and replaces them with `span` tags
- `filter-remove-separators` removes the separator elements from the block
- `filter-display-one-term` limits the output to one term
- any combination of the above 3 filter options can be set on block
- this solves all custom blocks we wanted to create for this issue, without needing the custom blocks. Obviously, the custom blocks would be much cleaner than this, but it does the job without needing them. It does however, force users to know that those classes exist.
- The filter doesn't work in the editor. The filter only works on the FE view of the block (this might be the biggest negative).
- The filter doesn't work with the prefix / suffix options available, I believe they just get removed.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-52)

Screenshots/video:
- Links removed and replaced with `<span>` tags: http://p.tri.be/i/lXXv5Q
