### PR TITLE
[CHORE] Update Block Editor Custom Alignments to 1.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,11 +86,11 @@
 			"type": "package",
 			"package": {
 				"name": "block-editor-custom-alignments/block-editor-custom-alignments",
-				"version": "1.0.5",
+				"version": "1.0.6",
 				"type": "wordpress-plugin",
 				"dist": {
 					"type": "zip",
-					"url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.5/block-editor-custom-alignments.1.0.5.zip"
+					"url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
 				},
 				"require": {
 					"ffraenz/private-composer-installer": "^5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -169,10 +169,10 @@
         },
         {
             "name": "block-editor-custom-alignments/block-editor-custom-alignments",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.5/block-editor-custom-alignments.1.0.5.zip"
+                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
             },
             "require": {
                 "ffraenz/private-composer-installer": "^5.0"


### PR DESCRIPTION
## What does this do/fix?

- updates Block Editor Custom Alignments plugin to 1.0.6 to fix some issues
