### PR TITLE
[FIX] update block registration function

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Block_Registrar.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Registrar.php
@@ -21,10 +21,7 @@ class Block_Registrar {
 			];
 		}
 
-		register_block_type(
-			trailingslashit( get_stylesheet_directory() ) . $blocks_dir . $block_name . '/block.json',
-			$args
-		);
+		register_block_type_from_metadata( trailingslashit( get_stylesheet_directory() ) . $blocks_dir . $block_name . '/block.json', $args );
 	}
 
 	/**


### PR DESCRIPTION
## What does this do/fix?

- Use `register_block_type_from_metadata` function (instead of `register_block_type`, which relies on the "name") for registering blocks since we're registering via the `block.json` file. `register_block_type` should work, but it makes a bit more sense to use the function that specifically is looking for the `block.json` file.
