### PR TITLE
[MOOSE-36] Search Results Template QA

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -14,6 +14,7 @@ use Tribe\Theme\blocks\core\paragraph\Paragraph;
 use Tribe\Theme\blocks\core\postterms\Post_Terms;
 use Tribe\Theme\blocks\core\querypagination\Query_Pagination;
 use Tribe\Theme\blocks\core\quote\Quote;
+use Tribe\Theme\blocks\core\search\Search;
 use Tribe\Theme\blocks\core\separator\Separator;
 use Tribe\Theme\blocks\core\spacer\Spacer;
 use Tribe\Theme\blocks\core\table\Table;
@@ -45,6 +46,7 @@ class Blocks_Definer implements Definer_Interface {
 				DI\get( Post_Terms::class ),
 				DI\get( Query_Pagination::class ),
 				DI\get( Quote::class ),
+				DI\get( Search::class ),
 				DI\get( Separator::class ),
 				DI\get( Spacer::class ),
 				DI\get( Table::class ),

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -88,6 +88,16 @@ select {
 	margin: 0;
 }
 
+/**
+ * Hide default "X" icon in webkit browsers for search inputs
+ */
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+	display: none;
+}
+
 :where(.wp-site-blocks) *:focus-visible {
 
 	@mixin focus-visible;

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -88,16 +88,6 @@ select {
 	margin: 0;
 }
 
-/**
- * Hide default "X" icon in webkit browsers for search inputs
- */
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-results-button,
-input[type="search"]::-webkit-search-results-decoration {
-	display: none;
-}
-
 :where(.wp-site-blocks) *:focus-visible {
 
 	@mixin focus-visible;

--- a/wp-content/themes/core/blocks/core/search/Search.php
+++ b/wp-content/themes/core/blocks/core/search/Search.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Theme\blocks\core\search;
+
+use Tribe\Plugin\Blocks\Block_Base;
+
+class Search extends Block_Base {
+
+	public function get_block_name(): string {
+		return 'core/search';
+	}
+
+	public function get_block_path(): string {
+		return 'core/search';
+	}
+
+}

--- a/wp-content/themes/core/blocks/core/search/index.js
+++ b/wp-content/themes/core/blocks/core/search/index.js
@@ -1,0 +1,5 @@
+/**
+ * Scripts specific to this block
+ */
+
+import './style.pcss';

--- a/wp-content/themes/core/blocks/core/search/style.pcss
+++ b/wp-content/themes/core/blocks/core/search/style.pcss
@@ -1,0 +1,13 @@
+/**
+ * Styles specific to this block
+ */
+
+/**
+ * Hide default "X" icon in webkit browsers for search inputs
+ */
+.wp-block-search__input::-webkit-search-decoration,
+.wp-block-search__input::-webkit-search-cancel-button,
+.wp-block-search__input::-webkit-search-results-button,
+.wp-block-search__input::-webkit-search-results-decoration {
+	display: none;
+}

--- a/wp-content/themes/core/blocks/tribe/query-results-count/render.php
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/render.php
@@ -2,7 +2,7 @@
 
 global $wp_query;
 $is_search = is_search();
-$count     = (int) $wp_query->post_count;
+$count     = (int) $wp_query->found_posts;
 $output    = sprintf( _n( '%d result', '%d results', $count, 'tribe' ), number_format_i18n( $count ) );
 
 if ( $is_search ) {

--- a/wp-content/themes/core/blocks/tribe/query-results-count/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/style.pcss
@@ -12,4 +12,12 @@
 	.search-term {
 		font-weight: 700;
 	}
+
+	/**
+	 * hide block if there are no search results
+	 * only applies to search results template.
+	 */
+	.search-no-results & {
+		display: none;
+	}
 }

--- a/wp-content/themes/core/parts/pagination.html
+++ b/wp-content/themes/core/parts/pagination.html
@@ -1,5 +1,0 @@
-<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
-<!-- wp:query-pagination-numbers /-->
-<!-- wp:query-pagination-next {"label":"Next Page"} /-->
-<!-- /wp:query-pagination -->

--- a/wp-content/themes/core/templates/search.html
+++ b/wp-content/themes/core/templates/search.html
@@ -28,12 +28,8 @@
 <!-- /wp:post-template -->
 
 <!-- wp:query-no-results -->
-<!-- wp:heading {"textAlign":"left"} -->
-<h2 class="wp-block-heading has-text-align-left">No results found</h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Sorry, but nothing matched your search terms. Please try again with some different keywords.</p>
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Your search query returned no results. Try another search term.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer {"height":"50px"} -->
@@ -41,7 +37,11 @@
 <!-- /wp:spacer -->
 <!-- /wp:query-no-results -->
 
-<!-- wp:template-part {"slug":"pagination","theme":"core","area":"uncategorized"} /--></div>
+<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+<!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-next {"label":"Next Page"} /-->
+<!-- /wp:query-pagination --></div>
 <!-- /wp:query --></main>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
## What does this do/fix?

- adds global reset for removing the default browser "X" (clear) button in search inputs that always confuse QA
- update post results count block to actually pull the total posts (pagination included)
- hide post results count block on the search results page if there are no results
- removes pagination template and moved it to the search template itself - this was causing issues with the pagination where it wouldn't receive the query context when using "inherit" queries.
- updates "no results" template according to the new design - unfortunately I can't get the search term in there without a custom block and I don't think that's super necessary for this
- **NOTE: WordPress still has an issue with the last page showing the No Results template if the last page only has one result.**

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-36)

Screenshots/video:
- Fixed Pagination 1: http://p.tri.be/i/gR3xMN
- Fixed Pagination 2: http://p.tri.be/i/TIRK6A
