### PR TITLE
Update Composer Platform and ACF Require

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,6 @@
 # Direct 1password link: https://m.tri.be/soenv10
 #
 # ACF Key has been move to the auth.json file with the license being used for
-# the username and the site url for the password.
+# the username and the full site url for the password.
 WP_PLUGIN_GF_KEY=''
 WP_PLUGIN_GF_TOKEN=''

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,7 @@
 # Find API keys in 1Password, in the Square One vault under "Square One .env"
 # Direct 1password link: https://m.tri.be/soenv10
-WP_PLUGIN_ACF_KEY=''
+#
+# ACF Key has been move to the auth.json file with the license being used for
+# the username and the site url for the password.
 WP_PLUGIN_GF_KEY=''
 WP_PLUGIN_GF_TOKEN=''

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ local-xdebuginfo.php
 /wp/
 .phpstan-cache/
 node_modules/
+auth.json
 
 wp-content/themes/core/dist/
 wp-content/plugins/core/dist/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It is recommeneded to create a blank blueprint in Local by Flywheel in order to 
 
 ### BE Setup
 
-Run `composer run setup-project` to copy the `.env`, `auth.json`, and `local-config` files over. Once that has completed, update the `.env` file to include the required license for Gravity Forms and update the `auth.json` to include the [ACF License for the username](https://www.advancedcustomfields.com/resources/installing-acf-pro-with-composer/) and the site url in the password section. Once the keys are up to date, run `composer install` to pull in the required libraries.  Then run `composer setup-wordpress` to install WordPress using WP Cli. Depending on your local environment you may need to update your `local-config.php` for the local environment you are working in.
+Run `composer run setup-project` to copy the `.env`, `auth.json`, and `local-config` files over. Once that has completed, update the `.env` file to include the required license for Gravity Forms and update the `auth.json` to include the [ACF License for the username](https://www.advancedcustomfields.com/resources/installing-acf-pro-with-composer/) and the site url (`https://moose.lndo.site`) in the password section. Once the keys are up to date, run `composer install` to pull in the required libraries.  Then run `composer setup-wordpress` to install WordPress using WP Cli. Depending on your local environment you may need to update your `local-config.php` for the local environment you are working in.
 
 ``` bash
 composer setup-project

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It is recommeneded to create a blank blueprint in Local by Flywheel in order to 
 
 ### BE Setup
 
-Run `composer run setup-project` to copy the `.env`, and `local-config` files over. Once that has completed, update the `.evn` file to include the required licenses for ACF Pro, and Gravity Forms. Once the keys are up to date, run `composer install` to pull in the required libraries.  Then run `composer setup-wordpress` to install WordPress using WP Cli. Depending on your local environment you may need to update your `local-config.php` for the local environment you are working in.
+Run `composer run setup-project` to copy the `.env`, `auth.json`, and `local-config` files over. Once that has completed, update the `.env` file to include the required license for Gravity Forms and update the `auth.json` to include the [ACF License for the username](https://www.advancedcustomfields.com/resources/installing-acf-pro-with-composer/) and the site url in the password section. Once the keys are up to date, run `composer install` to pull in the required libraries.  Then run `composer setup-wordpress` to install WordPress using WP Cli. Depending on your local environment you may need to update your `local-config.php` for the local environment you are working in.
 
 ``` bash
 composer setup-project

--- a/auth-sample.json
+++ b/auth-sample.json
@@ -2,7 +2,7 @@
 	"http-basic": {
 		"connect.advancedcustomfields.com": {
 			"username": "ACF License Key",
-			"password": "SITE_URL"
+			"password": "https://moose.lando.site"
 		}
 	}
 }

--- a/auth-sample.json
+++ b/auth-sample.json
@@ -1,0 +1,8 @@
+{
+	"http-basic": {
+		"connect.advancedcustomfields.com": {
+			"username": "ACF License Key",
+			"password": "SITE_URL"
+		}
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,11 @@
 			"cweagans/composer-patches": true,
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"phpstan/extension-installer": true
-		}
+		},
+		"platform": {
+			"php": "8.1"
+		},
+		"platform-check": false
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -22,6 +26,7 @@
 		"phpstan": "./vendor/bin/phpstan analyse --memory-limit=-1",
 		"setup-project": [
 			"@php -r \"file_exists('.env') || copy('.env.sample', '.env');\"",
+			"@php -r \"file_exists('auth.json') || copy('auth-sample.json', 'auth.json');\"",
 			"@php -r \"file_exists('local-config.php') || copy('local-config-sample.php', 'local-config.php');\"",
 			"@php -r \"file_exists('local-config.json') || copy('local-config-sample.json', 'local-config.json');\""
 		],
@@ -40,7 +45,7 @@
 		"phpcs": "Run PHPCS on the project.",
 		"phpcbf": "Run PHPCBF on the project.",
 		"phpstan": "Run PHPStan on the project.",
-		"setup-project": "Moves the .env, local-config.php, and local-config.json files for setting up the project.",
+		"setup-project": "Moves the .env, auth.json, local-config.php, and local-config.json files for setting up the project.",
 		"setup-wordpress": "Runs the wpcli command to download and install core WordPress. To change the WordPress version, update the --version value."
 	},
 	"repositories": [
@@ -68,19 +73,8 @@
 			}
 		},
 		{
-			"type": "package",
-			"package": {
-				"name": "advanced-custom-fields/advanced-custom-fields-pro",
-				"version": "6.1.8",
-				"type": "wordpress-plugin",
-				"dist": {
-					"type": "zip",
-					"url": "https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&k={%WP_PLUGIN_ACF_KEY}&t={%VERSION}"
-				},
-				"require": {
-					"ffraenz/private-composer-installer": "^5.0"
-				}
-			}
+			"type": "composer",
+			"url": "https://connect.advancedcustomfields.com"
 		},
 		{
 			"type": "package",
@@ -116,8 +110,7 @@
 		"wpackagist-plugin/debug-bar": "^1.1"
 	},
 	"require": {
-		"php": "^7.4|^8.0",
-		"advanced-custom-fields/advanced-custom-fields-pro": "*",
+		"php": "^8.0|^8.1",
 		"block-editor-custom-alignments/block-editor-custom-alignments": "*",
 		"composer/installers": "^2.2",
 		"gravityforms/gravityforms": "*",
@@ -138,7 +131,8 @@
 		"wpackagist-plugin/safe-svg": "^2.1",
 		"wpackagist-plugin/user-switching": "^1.7",
 		"wpackagist-plugin/wordpress-seo": "^20.1",
-		"wpackagist-plugin/wp-tota11y": "^1.2"
+		"wpackagist-plugin/wp-tota11y": "^1.2",
+		"wpengine/advanced-custom-fields-pro": "6.2"
 	},
 	"extra": {
 		"installer-paths": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "190c9820cedabdc777a242fabe2ce260",
+    "content-hash": "66272c6d22b3e8c7aba47d125b5e01e1",
     "packages": [
-        {
-            "name": "advanced-custom-fields/advanced-custom-fields-pro",
-            "version": "6.1.8",
-            "dist": {
-                "type": "zip",
-                "url": "https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&k={%WP_PLUGIN_ACF_KEY}&t={%VERSION}"
-            },
-            "require": {
-                "ffraenz/private-composer-installer": "^5.0"
-            },
-            "type": "wordpress-plugin"
-        },
         {
             "name": "aws/aws-crt-php",
             "version": "v1.2.2",
@@ -74,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.277.11",
+            "version": "3.277.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "c34f137abd571a9a19e290ce0b6fc6fc80f559b6"
+                "reference": "2f7c7f7d4c949469eca4e4c18fb5646aafb0375c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c34f137abd571a9a19e290ce0b6fc6fc80f559b6",
-                "reference": "c34f137abd571a9a19e290ce0b6fc6fc80f559b6",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2f7c7f7d4c949469eca4e4c18fb5646aafb0375c",
+                "reference": "2f7c7f7d4c949469eca4e4c18fb5646aafb0375c",
                 "shasum": ""
             },
             "require": {
@@ -163,9 +151,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.277.11"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.277.12"
             },
-            "time": "2023-08-08T18:06:20+00:00"
+            "time": "2023-08-09T18:09:09+00:00"
         },
         {
             "name": "block-editor-custom-alignments/block-editor-custom-alignments",
@@ -6513,6 +6501,21 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wp-tota11y/"
+        },
+        {
+            "name": "wpengine/advanced-custom-fields-pro",
+            "version": "6.2.0",
+            "dist": {
+                "type": "zip",
+                "url": "https://connect.advancedcustomfields.com/v2/plugins/composer_download?p=pro&t=6.2.0"
+            },
+            "require": {
+                "composer/installers": "~1.0 || ~2.0"
+            },
+            "replace": {
+                "wpackagist-plugin/advanced-custom-fields": "self.version"
+            },
+            "type": "wordpress-plugin"
         }
     ],
     "packages-dev": [
@@ -11768,8 +11771,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4|^8.0"
+        "php": "^8.0|^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## What does this do/fix?

Adds a platform option to the composer config to make sure even if you run composer using a different version of php, it will still download for 8.1. 

Changes the composer require for ACF to the [recommended version by WP Engine](https://www.advancedcustomfields.com/resources/installing-acf-pro-with-composer/). 
