### PR TITLE
[FIX] WP 6.3 Block Styles Support

### DIFF
--- a/wp-content/plugins/core/src/Theme_Config/Theme_Support.php
+++ b/wp-content/plugins/core/src/Theme_Config/Theme_Support.php
@@ -12,7 +12,6 @@ class Theme_Support {
 		$this->support_title_tag();
 		$this->support_responsive_embeds();
 		$this->support_html5();
-		$this->support_block_styles();
 		$this->remove_support_block_widgets();
 	}
 
@@ -60,13 +59,6 @@ class Theme_Support {
 			'script',
 			'style',
 		] );
-	}
-
-	/**
-	 * Support: default Gutenberg block styles in the theme.
-	 */
-	private function support_block_styles(): void {
-		add_theme_support( 'wp-block-styles' );
 	}
 
 	/**

--- a/wp-content/themes/core/blocks/core/lists/style.pcss
+++ b/wp-content/themes/core/blocks/core/lists/style.pcss
@@ -29,23 +29,15 @@
 
 :where(.wp-site-blocks) ul,
 :is(.editor-styles-wrapper) ul.wp-block-list {
-	padding-inline-start: 0;
+	padding-inline-start: 10px;
 
 	& li {
-		padding-inline-start: 1.75rem;
+		padding-inline-start: 1.3rem;
 		position: relative;
 
 		&::marker {
-			content: "";
-		}
-
-		&::before {
 			content: var(--icon-list-bullet);
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 10px;
-			height: 10px;
+			transform: translateX(10px);
 		}
 
 		& ~ li {

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -439,19 +439,10 @@
 				}
 			},
 			"core/quote": {
-				"border": {
-					"left": {
-						"width": "0",
-						"color": "currentcolor"
-					}
-				},
 				"spacing": {
 					"margin": {
 						"top": "2rem",
 						"bottom": "2rem"
-					},
-					"padding": {
-						"left": "0"
 					}
 				},
 				"typography": {

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -402,10 +402,12 @@
 				"border": {
 					"top": {
 						"width": "3px",
+						"style": "solid",
 						"color": "currentcolor"
 					},
 					"bottom": {
 						"width": "3px",
+						"style": "solid",
 						"color": "currentcolor"
 					}
 				},
@@ -430,7 +432,8 @@
 							"fontSize": "var(--wp--preset--font-size--20)",
 							"fontWeight": "var(--wp--custom--font-weight--regular)",
 							"lineHeight": "1.5",
-							"textTransform": "none"
+							"textTransform": "none",
+							"fontStyle": "normal"
 						}
 					}
 				}
@@ -462,7 +465,8 @@
 							"fontSize": "var(--wp--preset--font-size--20)",
 							"fontWeight": "var(--wp--custom--font-weight--regular)",
 							"lineHeight": "1.5",
-							"textTransform": "none"
+							"textTransform": "none",
+							"fontStyle": "normal"
 						}
 					}
 				}


### PR DESCRIPTION
## What does this do/fix?

- remove block styles support
- update items in styleguide that don't quite match after removing styles 
