### PR TITLE
[FEATURE] Exclude Current Post from Related Posts Query Loop Block

### DIFF
--- a/wp-content/plugins/core/src/Post_Types/Page/Config.php
+++ b/wp-content/plugins/core/src/Post_Types/Page/Config.php
@@ -21,4 +21,14 @@ class Config {
 		];
 	}
 
+	public function filter_single_post_query_block( array $query ): array {
+		if ( ! is_single() || 'post' !== $query['post_type'] ) {
+			return $query;
+		}
+
+		$query['post__not_in'] = [ get_the_ID() ];
+
+		return $query;
+	}
+
 }

--- a/wp-content/plugins/core/src/Post_Types/Page/Page_Subscriber.php
+++ b/wp-content/plugins/core/src/Post_Types/Page/Page_Subscriber.php
@@ -8,12 +8,19 @@ class Page_Subscriber extends Abstract_Subscriber {
 
 	public function register(): void {
 		$this->block_templates();
+		$this->query_loop_block_filter();
 	}
 
 	public function block_templates(): void {
 		add_action( 'init', function (): void {
 			$this->container->get( Config::class )->register_block_template();
 		} );
+	}
+
+	public function query_loop_block_filter(): void {
+		add_filter( 'query_loop_block_query_vars', function ( array $query ): array {
+			return $this->container->get( Config::class )->filter_single_post_query_block( $query );
+		}, 10, 1 );
 	}
 
 }


### PR DESCRIPTION
## What does this do/fix?

- We are currently displaying "Related Posts" on the single post template.
- Currently, there isn't a way to remove the current post from a Query Loop block on the post. 
- Using the `query_loop_block_query_vars` filter, we can target the `WP_Query` array in order to add a `post__not_in` check automatically to the post's FE, which will exclude it from the query block.
- NOTE: This doesn't work in the editor, only on the FE.

## QA

Screenshots/video:
- Before: http://p.tri.be/i/riCkCn
- After: http://p.tri.be/i/GVnMnG
