### PR TITLE
Adds GTM4WP Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [2023.08]
 
+- Added: GTM4WP Plugin for handling Google Tag Manager.
 - Updated: Deployments to use the secrets.COMPOSER_AUTH_JSON for auth.json file.
 - Updated: Composer method for pulling in ACF requiring the use of a auth.json file.
 - Updated: WordPress core to 6.3, ACF to 6.2, Gravity Forms to 2.7.12, Local Lando PHP version to 8.1, Yoast SEO to ^20.1.

--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,7 @@
 		"vlucas/phpdotenv": "^5.5",
 		"wp-cli/wp-cli-bundle": "^2.8",
 		"wpackagist-plugin/disable-emojis": "^1.7",
+		"wpackagist-plugin/duracelltomi-google-tag-manager": "1.16.2",
 		"wpackagist-plugin/limit-login-attempts-reloaded": "^2.25",
 		"wpackagist-plugin/redirection": "^5.3",
 		"wpackagist-plugin/safe-svg": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66272c6d22b3e8c7aba47d125b5e01e1",
+    "content-hash": "2d2e884386855584715f5849e4940629",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6386,6 +6386,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/disable-emojis/"
+        },
+        {
+            "name": "wpackagist-plugin/duracelltomi-google-tag-manager",
+            "version": "1.16.2",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/duracelltomi-google-tag-manager/",
+                "reference": "tags/1.16.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/duracelltomi-google-tag-manager.1.16.2.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/duracelltomi-google-tag-manager/"
         },
         {
             "name": "wpackagist-plugin/limit-login-attempts-reloaded",


### PR DESCRIPTION
## What does this do/fix?

Adds the [GTM4WP](https://wordpress.org/plugins/duracelltomi-google-tag-manager/) plugin for handling Google Tag Manager. 

