### PR TITLE
Updates GTM4WP and Limit Login Attempts Reloaded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
 		"vlucas/phpdotenv": "^5.5",
 		"wp-cli/wp-cli-bundle": "^2.8",
 		"wpackagist-plugin/disable-emojis": "^1.7",
-		"wpackagist-plugin/duracelltomi-google-tag-manager": "1.16.2",
+		"wpackagist-plugin/duracelltomi-google-tag-manager": "^1.18",
 		"wpackagist-plugin/limit-login-attempts-reloaded": "^2.25",
 		"wpackagist-plugin/redirection": "^5.3",
 		"wpackagist-plugin/safe-svg": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d2e884386855584715f5849e4940629",
+    "content-hash": "505a0e45348108a80d4446090a882a3b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6389,15 +6389,15 @@
         },
         {
             "name": "wpackagist-plugin/duracelltomi-google-tag-manager",
-            "version": "1.16.2",
+            "version": "1.18",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/duracelltomi-google-tag-manager/",
-                "reference": "tags/1.16.2"
+                "reference": "tags/1.18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/duracelltomi-google-tag-manager.1.16.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/duracelltomi-google-tag-manager.1.18.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -6407,15 +6407,15 @@
         },
         {
             "name": "wpackagist-plugin/limit-login-attempts-reloaded",
-            "version": "2.25.21",
+            "version": "2.25.22",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/limit-login-attempts-reloaded/",
-                "reference": "tags/2.25.21"
+                "reference": "tags/2.25.22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/limit-login-attempts-reloaded.2.25.21.zip"
+                "url": "https://downloads.wordpress.org/plugin/limit-login-attempts-reloaded.2.25.22.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
## What does this do/fix?

Updates plugins: 
- GTM4WP to 1.18
- Limit Login Attempts Reloaded to 2.25.22