### PR TITLE
[FIX] Update Styleguide Pattern for WP 6.3

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -16,6 +16,7 @@ use Tribe\Theme\blocks\core\paragraph\Paragraph;
 use Tribe\Theme\blocks\core\postauthorname\Post_Author_Name;
 use Tribe\Theme\blocks\core\posttemplate\Post_Template;
 use Tribe\Theme\blocks\core\postterms\Post_Terms;
+use Tribe\Theme\blocks\core\pullquote\Pullquote;
 use Tribe\Theme\blocks\core\querypagination\Query_Pagination;
 use Tribe\Theme\blocks\core\quote\Quote;
 use Tribe\Theme\blocks\core\search\Search;
@@ -52,6 +53,7 @@ class Blocks_Definer implements Definer_Interface {
 				DI\get( Post_Author_Name::class ),
 				DI\get( Post_Template::class ),
 				DI\get( Post_Terms::class ),
+				DI\get( Pullquote::class ),
 				DI\get( Query_Pagination::class ),
 				DI\get( Quote::class ),
 				DI\get( Search::class ),

--- a/wp-content/themes/core/blocks/core/pullquote/Pullquote.php
+++ b/wp-content/themes/core/blocks/core/pullquote/Pullquote.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Theme\blocks\core\pullquote;
+
+use Tribe\Plugin\Blocks\Block_Base;
+
+class Pullquote extends Block_Base {
+
+	public function get_block_name(): string {
+		return 'core/pullquote';
+	}
+
+}

--- a/wp-content/themes/core/blocks/core/pullquote/index.js
+++ b/wp-content/themes/core/blocks/core/pullquote/index.js
@@ -1,0 +1,5 @@
+/**
+ * Scripts specific to this block
+ */
+
+import './style.pcss';

--- a/wp-content/themes/core/blocks/core/pullquote/style.pcss
+++ b/wp-content/themes/core/blocks/core/pullquote/style.pcss
@@ -1,0 +1,12 @@
+/**
+ * Styles specific to this block
+ */
+
+.wp-block-pullquote {
+
+	> blockquote p {
+		font-size: var(--wp--preset--font-size--50);
+		font-weight: var(--wp--custom--font-weight--bold);
+		line-height: 1.2;
+	}
+}

--- a/wp-content/themes/core/blocks/core/quote/index.js
+++ b/wp-content/themes/core/blocks/core/quote/index.js
@@ -1,0 +1,5 @@
+/**
+ * Scripts specific to this block
+ */
+
+import './style.pcss';

--- a/wp-content/themes/core/blocks/core/quote/style.pcss
+++ b/wp-content/themes/core/blocks/core/quote/style.pcss
@@ -1,0 +1,12 @@
+/**
+ * Styles specific to this block
+ */
+
+.wp-block-quote {
+
+	> p {
+		font-size: var(--wp--preset--font-size--30);
+		font-weight: var(--wp--custom--font-weight--bold);
+		line-height: 1.4;
+	}
+}

--- a/wp-content/themes/core/patterns/styleguide.php
+++ b/wp-content/themes/core/patterns/styleguide.php
@@ -8,8 +8,7 @@
  * Keywords: styleguide, text, buttons, quote, image, table
  */
 ?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":1} -->
+<!-- wp:heading {"level":1} -->
 <h1 class="wp-block-heading">Building a braver, brighter, better connected world.</h1>
 <!-- /wp:heading -->
 
@@ -33,35 +32,63 @@
 <h6 class="wp-block-heading">Building a braver, brighter, better connected world.</h6>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"className":"is-style-large"} -->
-<p class="is-style-large" style="margin-bottom:var(--wp--preset--spacing--30)">Whatever we’re working on, we push what’s possible to accomplish ambitious goals, to serve your communities, and to build a braver, brighter, better connected world. Here’s how we make it happen.</p>
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:paragraph {"className":"is-style-large"} -->
+<p class="is-style-large">Whatever we’re working on, we push what’s possible to accomplish ambitious goals, to serve your communities, and to build a braver, brighter, better connected world. Here’s how we make it happen.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-<p style="margin-bottom:var(--wp--preset--spacing--30)">Whatever we’re working on, we push what’s possible to accomplish ambitious goals, to serve your communities, and to build a braver, brighter, better connected world. Here’s how we make it happen.</p>
+<!-- wp:spacer {"className":"is-style-medium"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p>Whatever we’re working on, we push what’s possible to accomplish ambitious goals, to serve your communities, and to build a braver, brighter, better connected world. Here’s how we make it happen.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"className":"is-style-small"} -->
-<p class="is-style-small" style="margin-bottom:var(--wp--preset--spacing--30)">Whatever we’re working on, we push what’s possible to accomplish ambitious goals, to serve your communities, and to build a braver, brighter, better connected world. Here’s how we make it happen.</p>
+<!-- wp:spacer {"className":"is-style-medium"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"className":"is-style-small"} -->
+<p class="is-style-small">Whatever we’re working on, we push what’s possible to accomplish ambitious goals, to serve your communities, and to build a braver, brighter, better connected world. Here’s how we make it happen.</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
 
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-primary"} -->
-<div class="wp-block-button is-style-primary"><a class="wp-block-button__link wp-element-button" href="https://www.google.com" target="_blank" rel="noreferrer noopener">Primary Button</a></div>
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Default Button</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"className":"is-style-primary"} -->
+<div class="wp-block-button is-style-primary"><a class="wp-block-button__link wp-element-button">Primary Button</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"className":"is-style-secondary"} -->
-<div class="wp-block-button is-style-secondary"><a class="wp-block-button__link wp-element-button" href="https://www.google.com" target="_blank" rel="noreferrer noopener">Secondary Button</a></div>
+<div class="wp-block-button is-style-secondary"><a class="wp-block-button__link wp-element-button">Secondary Button</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"className":"is-style-ghost"} -->
-<div class="wp-block-button is-style-ghost"><a class="wp-block-button__link wp-element-button" href="https://www.google.com" target="_blank" rel="noreferrer noopener">Tertiary Button</a></div>
+<div class="wp-block-button is-style-ghost"><a class="wp-block-button__link wp-element-button">Ghost Button</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","right":"0","bottom":"var:preset|spacing|30","left":"0"}}}} -->
-<p style="margin-top:var(--wp--preset--spacing--30);margin-right:0;margin-bottom:var(--wp--preset--spacing--30);margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt <a rel="noreferrer noopener" href="https://www.google.com" target="_blank">this is an inline link</a> ut labore et dolore magna aliqua. Urna nunc id cursus metus aliquam eleifend mi in nulla. Eu volutpat odio facilisis mauris sit amet massa vitae tortor. Dui accumsan <a rel="noreferrer noopener" href="https://www.google.com" target="_blank">this is an inline link on hover</a> tempus iaculis. Tellus cras adipiscing enim eu turpis egestas pretium. <em>This is some italic text</em> eu consequat ac felis donec et. Viverra vitae congue eu consequat ac felis donec et. Praesent tristique magna sit amet purus. <strong>This is some bold text</strong> purus gravida quis blandit turpis cursus.</p>
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt <a href="https://www.google.com/" target="_blank" rel="noreferrer noopener">this is an inline link</a> ut labore et dolore magna aliqua. Urna nunc id cursus metus aliquam eleifend mi in nulla. Eu volutpat odio facilisis mauris sit amet massa vitae tortor. Dui accumsan <a href="https://www.google.com" target="_blank" rel="noreferrer noopener">this is an inline link on hover</a> tempus iaculis. Tellus cras adipiscing enim eu turpis egestas pretium. Vitae congue eu consequat ac felis donec et. Viverra vitae congue eu consequat ac felis donec et. Praesent tristique magna sit amet purus. Magna sit amet purus gravida quis blandit turpis cursus.</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
 
 <!-- wp:list {"ordered":true} -->
 <ol><!-- wp:list-item -->
@@ -77,9 +104,9 @@
 <!-- /wp:list-item --></ol>
 <!-- /wp:list -->
 
-<!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
+<!-- wp:spacer {"className":"is-style-medium"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
@@ -95,37 +122,36 @@
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
-<!-- wp:spacer {"className":"is-style-medium"} -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
-<!-- /wp:spacer -->
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
 
-<!-- wp:pullquote {"textAlign":"left"} -->
-<figure class="wp-block-pullquote has-text-align-left"><blockquote><p>“We design and engineer each touchpoint across your ecosystem, from websites and applications to plugins and publishing platforms.”</p><cite>Citation</cite></blockquote></figure>
+<!-- wp:pullquote {"textAlign":"left","align":"wide"} -->
+<figure class="wp-block-pullquote alignwide has-text-align-left"><blockquote><p>“We design and engineer each touchpoint across your ecosystem, from websites and applications to plugins and publishing platforms.”</p><cite>Citation</cite></blockquote></figure>
 <!-- /wp:pullquote -->
 
-<!-- wp:spacer {"className":"is-style-medium"} -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
-<!-- /wp:spacer -->
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
 
 <!-- wp:quote -->
-<blockquote class="wp-block-quote"><!-- wp:paragraph -->
-<p>“We design and engineer each touchpoint across your ecosystem, from websites and applications to plugins and publishing platforms.”</p>
+<blockquote class="wp-block-quote"><!-- wp:paragraph {"className":"is-style-default"} -->
+<p class="is-style-default">“We design and engineer each touchpoint across your ecosystem, from websites and applications to plugins and publishing platforms.”</p>
 <!-- /wp:paragraph --><cite>Citation</cite></blockquote>
 <!-- /wp:quote -->
 
-<!-- wp:spacer {"className":"is-style-medium"} -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
-<!-- /wp:spacer -->
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
 
 <!-- wp:image {"sizeSlug":"large"} -->
 <figure class="wp-block-image size-large"><img src="https://picsum.photos/640/380" alt=""/><figcaption class="wp-element-caption">Caption lorem ipsum fusce fringilla luctus suscipit. Vivamus elit enim, dapibus sed mollis nec, cursus nec ante. Aliquam erat volutpat.</figcaption></figure>
 <!-- /wp:image -->
 
-<!-- wp:spacer {"className":"is-style-medium"} -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-medium"></div>
-<!-- /wp:spacer -->
+<!-- wp:separator {"align":"full"} -->
+<hr class="wp-block-separator alignfull has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
 
 <!-- wp:table -->
 <figure class="wp-block-table"><table><thead><tr><th>Header label</th><th>Header label</th><th>Header label</th></tr></thead><tbody><tr><td>Cell label</td><td>Cell label</td><td>Cell label</td></tr><tr><td>Cell label</td><td>Cell label</td><td>Cell label</td></tr><tr><td>Cell label</td><td>Cell label</td><td>Cell label</td></tr></tbody><tfoot><tr><td>Footer label</td><td>Footer label</td><td>Footer label</td></tr></tfoot></table></figure>
-<!-- /wp:table --></div>
-<!-- /wp:group -->
+<!-- /wp:table -->

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -421,11 +421,6 @@
 						"bottom": "var(--wp--preset--spacing--40)"
 					}
 				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--50)",
-					"fontWeight": "var(--wp--custom--font-weight--bold)",
-					"lineHeight": "1.2"
-				},
 				"elements": {
 					"cite": {
 						"typography": {
@@ -436,7 +431,8 @@
 							"fontStyle": "normal"
 						}
 					}
-				}
+				},
+				"css": "> blockquote p {font-size: var(--wp--preset--font-size--50); font-weight: var(--wp--custom--font-weight--bold); line-height: 1.2;}"
 			},
 			"core/quote": {
 				"spacing": {
@@ -445,11 +441,6 @@
 						"bottom": "2rem"
 					}
 				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--30)",
-					"fontWeight": "var(--wp--custom--font-weight--bold)",
-					"lineHeight": "1.4"
-				},
 				"elements": {
 					"cite": {
 						"typography": {
@@ -460,7 +451,8 @@
 							"fontStyle": "normal"
 						}
 					}
-				}
+				},
+				"css": "> p {font-size: var(--wp--preset--font-size--30); font-weight: var(--wp--custom--font-weight--bold); line-height: 1.4;}"
 			},
 			"core/table": {
 				"typography": {

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -431,8 +431,7 @@
 							"fontStyle": "normal"
 						}
 					}
-				},
-				"css": "> blockquote p {font-size: var(--wp--preset--font-size--50); font-weight: var(--wp--custom--font-weight--bold); line-height: 1.2;}"
+				}
 			},
 			"core/quote": {
 				"spacing": {
@@ -451,8 +450,7 @@
 							"fontStyle": "normal"
 						}
 					}
-				},
-				"css": "> p {font-size: var(--wp--preset--font-size--30); font-weight: var(--wp--custom--font-weight--bold); line-height: 1.4;}"
+				}
 			},
 			"core/table": {
 				"typography": {


### PR DESCRIPTION
## What does this do/fix?

- reworks styleguide pattern to be a little bit easier to read & work with, as well as updating all of the blocks to 6.3 so we no longer have any confusion with blocks using old formats.
- move typography for Pullquote & Quote block to a `css` option in `theme.json` - it appears that the `typography` settings for these blocks was being overridden by the Paragraph block. I don't know if it would be better to add the custom styles in our actual block styles or if this would be ok 🤔 


Screenshots/video:
![image](https://github.com/moderntribe/moose/assets/11410471/2a3d2a0e-d06f-4b3e-bc62-8ed5af50f311)

