### PR TITLE
[WIP] Slider (Swiper) Block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "moose",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"swiper": "^10.2.0"
+			},
 			"devDependencies": {
 				"@csstools/postcss-global-data": "^1.0.3",
 				"@wordpress/create-block": "^4.15.0",
@@ -17757,6 +17760,24 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/swiper": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-10.2.0.tgz",
+			"integrity": "sha512-nktQsOtBInJjr3f5DicxC8eHYGcLXDVIGPSon0QoXRaO6NjKnATCbQ8SZsD3dN1Ph1RH4EhVPwSYCcuDRFWHGQ==",
+			"funding": [
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/swiperjs"
+				},
+				{
+					"type": "open_collective",
+					"url": "http://opencollective.com/swiper"
+				}
+			],
+			"engines": {
+				"node": ">= 4.7.0"
 			}
 		},
 		"node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
 		"corePluginDir": "./wp-content/plugins/core",
 		"coreThemeBlocksDir": "./wp-content/themes/core/blocks"
 	},
+	"dependencies": {
+		"swiper": "^10.2.0"
+	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^1.0.3",
 		"@wordpress/create-block": "^4.15.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,34 +66,21 @@ const blockEntryPoints = () => {
 	 * contain a `block.json` file (they are already registered), but they
 	 * still may contain scripts or styles which should be processed.
 	 */
-	const coreBlockFiles = glob(
-		`${ pkg.config.coreThemeBlocksDir }/**/index.js`,
-		{ absolute: true }
-	);
+	const fileEntryPoints = [
+		...glob( `${ pkg.config.coreThemeBlocksDir }/**/index.js`, {
+			absolute: true,
+		} ),
+		...glob( `${ pkg.config.coreThemeBlocksDir }/**/editor.js`, {
+			absolute: true,
+		} ),
+		...glob( `${ pkg.config.coreThemeBlocksDir }/**/view.js`, {
+			absolute: true,
+		} ),
+	];
 
-	const coreBlockEditorFiles = glob(
-		`${ pkg.config.coreThemeBlocksDir }/**/editor.js`,
-		{ absolute: true }
-	);
-
-	const coreBlockViewFiles = glob(
-		`${ pkg.config.coreThemeBlocksDir }/**/view.js`,
-		{ absolute: true }
-	);
-
-	if (
-		! coreBlockFiles.length &&
-		! coreBlockEditorFiles.length &&
-		! coreBlockViewFiles.length
-	) {
+	if ( fileEntryPoints.length <= 0 ) {
 		return;
 	}
-
-	const fileEntryPoints = [
-		...coreBlockFiles,
-		...coreBlockEditorFiles,
-		...coreBlockViewFiles,
-	];
 
 	const entryPoints = {};
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,20 +76,28 @@ const blockEntryPoints = () => {
 		{ absolute: true }
 	);
 
-	if ( ! coreBlockFiles.length && ! coreBlockEditorFiles.length ) {
+	const coreBlockViewFiles = glob(
+		`${ pkg.config.coreThemeBlocksDir }/**/view.js`,
+		{ absolute: true }
+	);
+
+	if (
+		! coreBlockFiles.length &&
+		! coreBlockEditorFiles.length &&
+		! coreBlockViewFiles.length
+	) {
 		return;
 	}
 
+	const fileEntryPoints = [
+		...coreBlockFiles,
+		...coreBlockEditorFiles,
+		...coreBlockViewFiles,
+	];
+
 	const entryPoints = {};
 
-	coreBlockFiles.forEach( ( entryFilePath ) => {
-		const entryName = entryFilePath
-			.replace( extname( entryFilePath ), '' )
-			.replace( `${ resolve( pkg.config.coreThemeDir ) }/`, '' );
-		entryPoints[ entryName ] = entryFilePath;
-	} );
-
-	coreBlockEditorFiles.forEach( ( entryFilePath ) => {
+	fileEntryPoints.forEach( ( entryFilePath ) => {
 		const entryName = entryFilePath
 			.replace( extname( entryFilePath ), '' )
 			.replace( `${ resolve( pkg.config.coreThemeDir ) }/`, '' );

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -39,6 +39,8 @@ class Blocks_Definer implements Definer_Interface {
 				'tribe/post-type-name',
 				'tribe/post-permalink',
 				'tribe/query-results-count',
+				'tribe/slider-container',
+				'tribe/slider-slide',
 			] ),
 
 			self::EXTENDED        => DI\add( [

--- a/wp-content/themes/core/blocks/tribe/slider-container/block.json
+++ b/wp-content/themes/core/blocks/tribe/slider-container/block.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/slider-container",
+	"version": "0.1.0",
+	"title": "Slider Container",
+	"category": "theme",
+	"icon": "images-alt2",
+	"description": "A container block for a Swiper slider.",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": false
+		}
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": [ "file:./index.css", "file:./style-index.css"],
+	"style": [ "file:./index.css", "file:./style-index.css"]
+}

--- a/wp-content/themes/core/blocks/tribe/slider-container/block.json
+++ b/wp-content/themes/core/blocks/tribe/slider-container/block.json
@@ -17,6 +17,7 @@
 	},
 	"textdomain": "tribe",
 	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
 	"editorStyle": [ "file:./index.css", "file:./style-index.css"],
 	"style": [ "file:./index.css", "file:./style-index.css"]
 }

--- a/wp-content/themes/core/blocks/tribe/slider-container/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/edit.js
@@ -1,0 +1,70 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+/* eslint-disable */
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+
+import { Navigation, Pagination, A11y } from 'swiper/modules';
+import Swiper from 'swiper';
+/* eslint-enable */
+
+const TEMPLATE = [
+	[
+		'tribe/slider-slide',
+		{},
+		[ [ 'core/paragraph', { placeholder: 'Enter slide content...' } ] ],
+	],
+	[
+		'tribe/slider-slide',
+		{},
+		[ [ 'core/paragraph', { placeholder: 'Enter slide content...' } ] ],
+	],
+];
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+	const { children, ...innerBlockProps } = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'tribe/slider-slide' ],
+		template: TEMPLATE,
+	} );
+
+	new Swiper( '.swiper', {
+		modules: [ Navigation, Pagination, A11y ],
+		init: true,
+		loop: true,
+		navigation: {
+			nextEl: '.swiper-button-next',
+			prevEl: '.swiper-button-prev',
+			clickable: true,
+		},
+		pagination: {
+			el: '.swiper-pagination',
+			clickable: true,
+		},
+	} );
+
+	return (
+		<div { ...innerBlockProps }>
+			<div className="swiper">
+				<div className="swiper-wrapper">{ children }</div>
+				<div className="swiper-pagination"></div>
+				<div className="swiper-button-next"></div>
+				<div className="swiper-button-prev"></div>
+			</div>
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/slider-container/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/edit.js
@@ -44,6 +44,8 @@ export default function Edit() {
 		template: TEMPLATE,
 	} );
 
+	console.log( block );
+
 	useEffect( () => {
 		if (
 			block.current &&

--- a/wp-content/themes/core/blocks/tribe/slider-container/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/edit.js
@@ -44,8 +44,6 @@ export default function Edit() {
 		template: TEMPLATE,
 	} );
 
-	console.log( block );
-
 	useEffect( () => {
 		if (
 			block.current &&

--- a/wp-content/themes/core/blocks/tribe/slider-container/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/edit.js
@@ -37,7 +37,7 @@ const TEMPLATE = [
  */
 export default function Edit() {
 	const blockProps = useBlockProps();
-	const { children, ...innerBlockProps } = useInnerBlocksProps( blockProps, {
+	const { children } = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'tribe/slider-slide' ],
 		template: TEMPLATE,
 	} );
@@ -58,7 +58,7 @@ export default function Edit() {
 	} );
 
 	return (
-		<div { ...innerBlockProps }>
+		<div { ...blockProps }>
 			<div className="swiper">
 				<div className="swiper-wrapper">{ children }</div>
 				<div className="swiper-pagination"></div>

--- a/wp-content/themes/core/blocks/tribe/slider-container/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/edit.js
@@ -12,6 +12,7 @@ import {
 
 import { Navigation, Pagination, A11y } from 'swiper/modules';
 import Swiper from 'swiper';
+import swiperSettings from './swiper.json';
 /* eslint-enable */
 
 const TEMPLATE = [
@@ -44,17 +45,7 @@ export default function Edit() {
 
 	new Swiper( '.swiper', {
 		modules: [ Navigation, Pagination, A11y ],
-		init: true,
-		loop: true,
-		navigation: {
-			nextEl: '.swiper-button-next',
-			prevEl: '.swiper-button-prev',
-			clickable: true,
-		},
-		pagination: {
-			el: '.swiper-pagination',
-			clickable: true,
-		},
+		...swiperSettings,
 	} );
 
 	return (

--- a/wp-content/themes/core/blocks/tribe/slider-container/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/edit.js
@@ -9,7 +9,7 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-
+import { useRef, useEffect } from '@wordpress/element';
 import { Navigation, Pagination, A11y } from 'swiper/modules';
 import Swiper from 'swiper';
 import swiperSettings from './swiper.json';
@@ -37,20 +37,28 @@ const TEMPLATE = [
  * @return {WPElement} Element to render.
  */
 export default function Edit() {
+	const block = useRef( null );
 	const blockProps = useBlockProps();
 	const { children } = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'tribe/slider-slide' ],
 		template: TEMPLATE,
 	} );
 
-	new Swiper( '.swiper', {
-		modules: [ Navigation, Pagination, A11y ],
-		...swiperSettings,
+	useEffect( () => {
+		if (
+			block.current &&
+			! block.current.classList.contains( 'swiper-initialized' )
+		) {
+			new Swiper( '.swiper', {
+				modules: [ Navigation, Pagination, A11y ],
+				...swiperSettings,
+			} );
+		}
 	} );
 
 	return (
 		<div { ...blockProps }>
-			<div className="swiper">
+			<div ref={ block } className="swiper">
 				<div className="swiper-wrapper">{ children }</div>
 				<div className="swiper-pagination"></div>
 				<div className="swiper-button-next"></div>

--- a/wp-content/themes/core/blocks/tribe/slider-container/index.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/index.js
@@ -1,0 +1,46 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.pcss';
+
+/**
+ * Import Swiper styles
+ */
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import Save from './save';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save: Save,
+} );

--- a/wp-content/themes/core/blocks/tribe/slider-container/save.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/save.js
@@ -1,0 +1,28 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Save() {
+	return (
+		<div className="swiper">
+			<div className="swiper-wrapper">
+				<InnerBlocks.Content />
+			</div>
+			<div className="swiper-pagination"></div>
+			<div className="swiper-button-prev"></div>
+			<div className="swiper-button-next"></div>
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/slider-container/save.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/save.js
@@ -4,7 +4,7 @@
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * The edit function describes the structure of your block in the context of the
@@ -16,13 +16,15 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 export default function Save() {
 	return (
-		<div className="swiper">
-			<div className="swiper-wrapper">
-				<InnerBlocks.Content />
+		<div { ...useBlockProps.save() }>
+			<div className="swiper">
+				<div className="swiper-wrapper">
+					<InnerBlocks.Content />
+				</div>
+				<div className="swiper-pagination"></div>
+				<div className="swiper-button-prev"></div>
+				<div className="swiper-button-next"></div>
 			</div>
-			<div className="swiper-pagination"></div>
-			<div className="swiper-button-prev"></div>
-			<div className="swiper-button-next"></div>
 		</div>
 	);
 }

--- a/wp-content/themes/core/blocks/tribe/slider-container/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/slider-container/style.pcss
@@ -1,0 +1,6 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */

--- a/wp-content/themes/core/blocks/tribe/slider-container/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/slider-container/style.pcss
@@ -4,3 +4,18 @@
  *
  * Replace them with your own styles or remove the file completely.
  */
+
+.wp-block-tribe-slider-container {
+
+	/* set small height for the slider for easier testing */
+	.swiper {
+		height: 300px;
+	}
+
+	/* center everything in the slider for easier testing */
+	.swiper-slide {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}

--- a/wp-content/themes/core/blocks/tribe/slider-container/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/slider-container/style.pcss
@@ -11,11 +11,4 @@
 	.swiper {
 		height: 300px;
 	}
-
-	/* center everything in the slider for easier testing */
-	.swiper-slide {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
 }

--- a/wp-content/themes/core/blocks/tribe/slider-container/swiper.json
+++ b/wp-content/themes/core/blocks/tribe/slider-container/swiper.json
@@ -1,0 +1,13 @@
+{
+	"init": true,
+	"loop": true,
+	"navigation": {
+		"nextEl": ".swiper-button-next",
+		"prevEl": ".swiper-button-prev",
+		"clickable": true
+	},
+	"pagination": {
+		"el": ".swiper-pagination",
+		"clickable": true
+	}
+}

--- a/wp-content/themes/core/blocks/tribe/slider-container/view.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/view.js
@@ -1,0 +1,1 @@
+console.log( 'hi' );

--- a/wp-content/themes/core/blocks/tribe/slider-container/view.js
+++ b/wp-content/themes/core/blocks/tribe/slider-container/view.js
@@ -1,1 +1,11 @@
-console.log( 'hi' );
+import { ready } from 'utils/events';
+import { Navigation, Pagination, A11y } from 'swiper/modules';
+import Swiper from 'swiper';
+import swiperSettings from './swiper.json';
+
+ready( () => {
+	new Swiper( '.swiper', {
+		modules: [ Navigation, Pagination, A11y ],
+		...swiperSettings,
+	} );
+} );

--- a/wp-content/themes/core/blocks/tribe/slider-slide/block.json
+++ b/wp-content/themes/core/blocks/tribe/slider-slide/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/slider-slide",
+	"version": "0.1.0",
+	"title": "Slider Slide",
+	"category": "theme",
+	"icon": "format-image",
+	"description": "A slide block for a Swiper slider.",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"parent": [ "tribe/slider-container" ],
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css"
+}

--- a/wp-content/themes/core/blocks/tribe/slider-slide/edit.js
+++ b/wp-content/themes/core/blocks/tribe/slider-slide/edit.js
@@ -1,0 +1,27 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return (
+		<div className="swiper-slide">
+			<div { ...blockProps }>
+				<InnerBlocks />
+			</div>
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/slider-slide/index.js
+++ b/wp-content/themes/core/blocks/tribe/slider-slide/index.js
@@ -1,0 +1,39 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.pcss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import Save from './save';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save: Save,
+} );

--- a/wp-content/themes/core/blocks/tribe/slider-slide/save.js
+++ b/wp-content/themes/core/blocks/tribe/slider-slide/save.js
@@ -1,0 +1,23 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Save() {
+	return (
+		<div className="swiper-slide">
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/slider-slide/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/slider-slide/style.pcss
@@ -1,0 +1,6 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */

--- a/wp-content/themes/core/blocks/tribe/slider-slide/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/slider-slide/style.pcss
@@ -4,3 +4,18 @@
  *
  * Replace them with your own styles or remove the file completely.
  */
+
+/**
+ * this block doesn't get any wrapping classes as it only displays
+ * in the slider container block, we'll wrap it in that block here
+ * so we don't have any global issues
+ */
+.wp-block-tribe-slider-container {
+
+	/* center everything in the slider for easier testing */
+	.swiper-slide {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

- adds swiper dependency
- rewites block entry points function in `webpack.config.js` to be a bit more simple and easier to understand. This update also adds the ability to use `view.js` files within blocks. 
- adds two new blocks:
    - slider container
    - slider slide
- the Slider Container block does most of the heavy lifting for the blocks, initializing Swiper
- the Slider Slide block only exists so that we can easily add slides to the Slider Container block.
- 

## QA

Testing Environment
- http://moose-dev-pr95.d1.moderntribe.qa/

Screenshots/video:
- Demo video: 