### PR TITLE
Asset enqueue refactor

### DIFF
--- a/wp-content/plugins/core/src/Assets/Editor_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Editor_Assets_Enqueuer.php
@@ -11,7 +11,15 @@ class Editor_Assets_Enqueuer extends Assets_Enqueuer {
 	public function register(): void {
 		$args = $this->get_asset_file_args( $this->assets_path . self::ASSETS_FILE );
 
-		add_editor_style( $this->assets_path_uri . self::EDITOR_FILE_NAME . '.css' );
+		// add_editor_style( $this->assets_path_uri . self::EDITOR_FILE_NAME . '.css' );
+
+		wp_enqueue_style(
+			self::EDITOR,
+			$this->assets_path_uri . self::EDITOR_FILE_NAME . '.css',
+			[],
+			$args['version'] ?? false,
+			'all',
+		);
 
 		wp_enqueue_script(
 			self::EDITOR,

--- a/wp-content/plugins/core/src/Assets/Editor_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Editor_Assets_Enqueuer.php
@@ -11,8 +11,6 @@ class Editor_Assets_Enqueuer extends Assets_Enqueuer {
 	public function register(): void {
 		$args = $this->get_asset_file_args( $this->assets_path . self::ASSETS_FILE );
 
-		// add_editor_style( $this->assets_path_uri . self::EDITOR_FILE_NAME . '.css' );
-
 		wp_enqueue_style(
 			self::EDITOR,
 			$this->assets_path_uri . self::EDITOR_FILE_NAME . '.css',

--- a/wp-content/plugins/core/src/Blocks/Block_Base.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Base.php
@@ -26,6 +26,10 @@ abstract class Block_Base {
 		return $this->get_block_name();
 	}
 
+	public function get_block_style_handle(): string {
+		return str_replace( 'core/', 'wp-block-', $this->get_block_name() );
+	}
+
 	/**
 	 * Block styles to be defined in extending class
 	 *
@@ -62,33 +66,15 @@ abstract class Block_Base {
 	}
 
 	/**
-	 * Enqueue front-end block styles
+	 * Enqueue core block styles
+	 *
+	 * Adds the core block styles to both the public site and to the editor.
+	 * On the public site, styles are inlined into the document inside a `<style>` element.
+	 * Styles are added as a `<link>` for both block & site editor regardless of if it is inline or iframed.
+	 * Additionally, the selectors are prefixed with `.editor-styles-wrapper` in the editors.
 	 */
-	public function enqueue_core_block_front_style(): void {
-		$block    = $this->get_block_handle();
-		$path     = $this->get_block_path();
-		$args     = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/index.asset.php" ) );
-		$src_path = get_theme_file_path( "dist/blocks/$path/style-index.css" );
-		$src      = get_theme_file_uri( "dist/blocks/$path/style-index.css" );
-
-		if ( ! file_exists( $src_path ) ) {
-			return;
-		}
-
-		wp_enqueue_block_style( $this->get_block_name(), [
-			'handle' => "$block-styles",
-			'src'    => $src,
-			'deps'   => $this->get_block_dependencies(),
-			'ver'    => $args['version'] ?? false,
-			'media'  => 'all',
-		] );
-	}
-
-	/**
-	 * Enqueue core block editor front styles
-	 * These are the FE styles.
-	 */
-	public function enqueue_core_block_editor_front_style(): void {
+	public function enqueue_core_block_public_styles(): void {
+		$handle   = $this->get_block_style_handle();
 		$path     = $this->get_block_path();
 		$src_path = get_theme_file_path( "dist/blocks/$path/style-index.css" );
 		$src      = get_theme_file_uri( "dist/blocks/$path/style-index.css" );
@@ -97,17 +83,21 @@ abstract class Block_Base {
 			return;
 		}
 
+		wp_add_inline_style( $handle, file_get_contents( $src_path ) );
 		add_editor_style( $src );
 	}
 
 	/**
-	 * Enqueue core block editor admin (editor) styles
-	 * These are the editor specific style overrides for the block
+	 * Enqueue editor-specific styles
+	 *
+	 * These are the editor specific style overrides for the block.
+	 * Styles are added as a `<link>` file for both block & site editor regardless of if it is inline or iframed.
+	 * Additionally, the selectors are prefixed with `.editor-styles-wrapper` in the editors.
 	 */
-	public function enqueue_core_block_editor_style(): void {
+	public function enqueue_core_block_editor_styles(): void {
 		$path            = $this->get_block_path();
-		$editor_src_path = get_theme_file_path( "dist/blocks/$path/index.css" );
-		$editor_src      = get_theme_file_uri( "dist/blocks/$path/index.css" );
+		$editor_src_path = get_theme_file_path( "dist/blocks/$path/editor.css" );
+		$editor_src      = get_theme_file_uri( "dist/blocks/$path/editor.css" );
 
 		if ( ! file_exists( $editor_src_path ) ) {
 			return;
@@ -116,10 +106,10 @@ abstract class Block_Base {
 		add_editor_style( $editor_src );
 	}
 
-	public function enqueue_core_block_editor_script(): void {
+	public function enqueue_core_block_editor_scripts(): void {
 		$block    = $this->get_block_handle();
 		$path     = $this->get_block_path();
-		$args     = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/admin.asset.php" ) );
+		$args     = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/editor.asset.php" ) );
 		$src_path = get_theme_file_path( "dist/blocks/$path/editor.js" );
 		$src      = get_theme_file_uri( "dist/blocks/$path/editor.js" );
 

--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -32,33 +32,38 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 			}
 		}, 10, 0 );
 
-		// Register block CSS stylesheets - only runs on FE
-		if ( ! is_admin() ) {
-			add_action( 'after_setup_theme', function (): void {
-				foreach ( $this->container->get( Blocks_Definer::EXTENDED ) as $block ) {
-					$block->enqueue_core_block_front_style();
-				}
-			} );
-		}
+		/**
+		 * Enqueue styles on the public site for WP Core blocks
+		 */
+		add_action( 'wp_enqueue_scripts', function (): void {
+			foreach ( $this->container->get( Blocks_Definer::EXTENDED ) as $block ) {
+				// core block public styles
+				$block->enqueue_core_block_public_styles();
+			}
+		}, 10, 0 );
 
 		/**
-		 * Enqueue block editor styles / scripts
-		 *
-		 * Includes FE styles & editor styles so editor styles can override the FE ones
+		 * Enqueue styles in the editor for WP Core blocks
+		 */
+		add_action( 'admin_init', function (): void {
+			foreach ( $this->container->get( Blocks_Definer::EXTENDED ) as $block ) {
+				// core block public styles
+				$block->enqueue_core_block_public_styles();
+				// core block editor-only styles
+				$block->enqueue_core_block_editor_styles();
+			}
+		}, 10, 0 );
+
+		/**
+		 * Enqueue block editor-only scripts
 		 *
 		 * Core blocks shouldn't ever have FE scripts and should only include
 		 * editor scripts in order to override default block functionality
 		 */
 		add_action( 'enqueue_block_editor_assets', function (): void {
 			foreach ( $this->container->get( Blocks_Definer::EXTENDED ) as $block ) {
-				// core block front styles
-				$block->enqueue_core_block_editor_front_style();
-
-				// core block editor styles
-				$block->enqueue_core_block_editor_style();
-
-				// core block editor scripts
-				$block->enqueue_core_block_editor_script();
+				// core block editor-only scripts
+				$block->enqueue_core_block_editor_scripts();
 			}
 		}, 10, 0 );
 

--- a/wp-content/themes/core/assets/pcss/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/editor.pcss
@@ -10,7 +10,7 @@
 
 /* Global Theme Editor Styles */
 @import "layout/default.pcss";
-/*@import "global/reset.pcss";*/
+@import "global/reset.pcss";
 @import "typography/anchors.pcss";
 @import "typography/blockquote.pcss";
 

--- a/wp-content/themes/core/assets/pcss/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/editor.pcss
@@ -10,7 +10,7 @@
 
 /* Global Theme Editor Styles */
 @import "layout/default.pcss";
-@import "global/reset.pcss";
+/*@import "global/reset.pcss";*/
 @import "typography/anchors.pcss";
 @import "typography/blockquote.pcss";
 

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -69,7 +69,7 @@ picture {
  * within a site's content on a case-by-case basis.
  */
 
-/*iframe,*/
+/* iframe, */
 video,
 embed {
 	max-width: 100%;

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -64,10 +64,11 @@ picture {
 }
 
 /**
- * This `iframe` selector currently breaks pattern previews in the WordPress editors.
- * For now, we're going to leave it commented-out and address iframes within a site's
- * content on a case-by-case basis.
+ * This `iframe` selector currently breaks pattern previews in the WordPress
+ * editors. For now, we're going to leave it commented-out and address iframes
+ * within a site's content on a case-by-case basis.
  */
+
 /*iframe,*/
 video,
 embed {

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -69,7 +69,7 @@ picture {
  * within a site's content on a case-by-case basis.
  */
 
-/* iframe, */
+/*iframe,*/
 video,
 embed {
 	max-width: 100%;

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -64,12 +64,11 @@ picture {
 }
 
 /**
- * @todo Need to ensure we can properly enqueue this reset to prevent pattern
- * previews from disappearing in the editor. Although, they don't appear to
- * currently be breaking, maybe something to keep an eye on.
- * @see https://github.com/wpcomvip/careforth/pull/14
+ * This `iframe` selector currently breaks pattern previews in the WordPress editors.
+ * For now, we're going to leave it commented-out and address iframes within a site's
+ * content on a case-by-case basis.
  */
-iframe,
+/*iframe,*/
 video,
 embed {
 	max-width: 100%;


### PR DESCRIPTION
## What does this do/fix?
Fixes for asset enqueues with all the different contexts:
* Theme styles being properly loaded on the public website as well as the different editor contexts: post editor (inline or iframe) and site editor.
* Editor-only styles & scripts being properly loaded for both editors & contexts.

A couple things to address yet:
* I think we should go ahead and create a separate reset.pcss for the editor (or just reset styles we need to specifically?) rather than using our public reset.pcss in that context. It's not a blocker right now, but something we could address later.
* The `file_get_contents()` call used for inlining the styles is probably not the exact right approach. I think we need to adjust that for WPVIP's file system, correct?

- [Link to Video](https://www.loom.com/share/44b5c3cbce2a48e48b0e24ea3a5ae959)
- [Inlined block styles reference](https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/)

