### PR TITLE
[TRY] Button Block Variations

### DIFF
--- a/wp-content/themes/core/blocks/core/button/Button.php
+++ b/wp-content/themes/core/blocks/core/button/Button.php
@@ -10,12 +10,4 @@ class Button extends Block_Base {
 		return 'core/button';
 	}
 
-	public function get_block_styles(): array {
-		return [
-			'primary'   => esc_html__( 'Primary', 'tribe' ),
-			'secondary' => esc_html__( 'Secondary', 'tribe' ),
-			'ghost'     => esc_html__( 'Ghost', 'tribe' ),
-		];
-	}
-
 }

--- a/wp-content/themes/core/blocks/core/button/editor.js
+++ b/wp-content/themes/core/blocks/core/button/editor.js
@@ -3,9 +3,47 @@
  */
 
 import { ready } from 'utils/events.js';
-import { unregisterBlockStyle } from '@wordpress/blocks';
+import {
+	registerBlockVariation,
+	unregisterBlockStyle,
+} from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 ready( () => {
+	unregisterBlockStyle( 'core/button', 'default' );
 	unregisterBlockStyle( 'core/button', 'fill' );
 	unregisterBlockStyle( 'core/button', 'outline' );
+
+	registerBlockVariation( 'core/button', {
+		name: 'primary-button',
+		title: __( 'Primary', 'tribe' ),
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: {
+			className: 'is-style-primary',
+		},
+		icon: 'button',
+		isDefault: true,
+	} );
+
+	registerBlockVariation( 'core/button', {
+		name: 'secondary-button',
+		title: __( 'Secondary', 'tribe' ),
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: {
+			className: 'is-style-secondary',
+		},
+		icon: 'button',
+		isDefault: false,
+	} );
+
+	registerBlockVariation( 'core/button', {
+		name: 'ghost-button',
+		title: __( 'Ghost', 'tribe' ),
+		scope: [ 'block', 'inserter', 'transform' ],
+		attributes: {
+			className: 'is-style-ghost',
+		},
+		icon: 'button',
+		isDefault: false,
+	} );
 } );

--- a/wp-content/themes/core/patterns/styleguide.php
+++ b/wp-content/themes/core/patterns/styleguide.php
@@ -61,20 +61,16 @@
 <!-- /wp:separator -->
 
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Default Button</a></div>
-<!-- /wp:button -->
-
-<!-- wp:button {"className":"is-style-primary"} -->
-<div class="wp-block-button is-style-primary"><a class="wp-block-button__link wp-element-button">Primary Button</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-primary"} -->
+<div class="wp-block-button is-style-primary"><a class="wp-block-button__link wp-element-button">Button Text</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"className":"is-style-secondary"} -->
-<div class="wp-block-button is-style-secondary"><a class="wp-block-button__link wp-element-button">Secondary Button</a></div>
+<div class="wp-block-button is-style-secondary"><a class="wp-block-button__link wp-element-button">Button Text</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"className":"is-style-ghost"} -->
-<div class="wp-block-button is-style-ghost"><a class="wp-block-button__link wp-element-button">Ghost Button</a></div>
+<div class="wp-block-button is-style-ghost"><a class="wp-block-button__link wp-element-button">Button Text</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 


### PR DESCRIPTION
## What does this do/fix?

Adding most of you for visibility on this change. I definitely like this approach for the button block specifically as it allows us to get away from having that "Default" style on the block we really didn't want to have and forcing us to find ways to style that "Default" when it didn't even get a class.

- remove all block styles from the button block
- add 3 new block variations for the button block (Primary, Secondary, Ghost)
- this allows us to actually remove the "Default" block style (so we aren't stuck with an extra button we don't want), while still maintaining our current style system for the button block using 3 classes (`is-style-primary`, `is-style-secondary` and `is-style-ghost`).
- update styleguide pattern with new buttons

## QA

Screenshots/video:
- Demo video: https://www.loom.com/share/fb4f5b605dec4a86822779a9b3807a66
