### PR TITLE
[MOOSE-34] Misc Template Fixes

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -17,6 +17,7 @@ use Tribe\Theme\blocks\core\postauthorname\Post_Author_Name;
 use Tribe\Theme\blocks\core\posttemplate\Post_Template;
 use Tribe\Theme\blocks\core\postterms\Post_Terms;
 use Tribe\Theme\blocks\core\pullquote\Pullquote;
+use Tribe\Theme\blocks\core\querynoresults\Query_No_Results;
 use Tribe\Theme\blocks\core\querypagination\Query_Pagination;
 use Tribe\Theme\blocks\core\quote\Quote;
 use Tribe\Theme\blocks\core\search\Search;
@@ -54,6 +55,7 @@ class Blocks_Definer implements Definer_Interface {
 				DI\get( Post_Template::class ),
 				DI\get( Post_Terms::class ),
 				DI\get( Pullquote::class ),
+				DI\get( Query_No_Results::class ),
 				DI\get( Query_Pagination::class ),
 				DI\get( Quote::class ),
 				DI\get( Search::class ),

--- a/wp-content/themes/core/assets/pcss/cards/post.pcss
+++ b/wp-content/themes/core/assets/pcss/cards/post.pcss
@@ -14,6 +14,7 @@
 
 .p-card-post {
 	position: relative;
+	container: postcard / inline-size;
 }
 
 /* -----------------------------------------------------------------------
@@ -34,7 +35,7 @@
 		}
 	}
 
-	@media (--viewport-small-max) {
+	@container (max-width: 320px) {
 		width: 22% !important;
 		float: right;
 		margin-inline-start: 2em;

--- a/wp-content/themes/core/blocks/core/lists/style.pcss
+++ b/wp-content/themes/core/blocks/core/lists/style.pcss
@@ -4,6 +4,12 @@
 
 /* ----------------------------------------------------------------------
  * Ordered List
+ *
+ * The first selector applies to the FE, the second in the editor.
+ * The list block is the only block on the FE that doesn't get a class,
+ * so we're able to apply a :not() selector for the class attribute.
+ * While both will apply in the editor, only the second will affect
+ * the actual list block.
  * ---------------------------------------------------------------------- */
 
 .wp-site-blocks ol:not([class]),
@@ -25,6 +31,12 @@ ol.wp-block-list {
 
 /* ----------------------------------------------------------------------
  * Unordered List
+ *
+ * The first selector applies to the FE, the second in the editor.
+ * The list block is the only block on the FE that doesn't get a class,
+ * so we're able to apply a :not() selector for the class attribute.
+ * While both will apply in the editor, only the second will affect
+ * the actual list block.
  * ---------------------------------------------------------------------- */
 
 .wp-site-blocks ul:not([class]),

--- a/wp-content/themes/core/blocks/core/posttemplate/style.pcss
+++ b/wp-content/themes/core/blocks/core/posttemplate/style.pcss
@@ -5,7 +5,7 @@
 /**
  * Vertical (list layout) post template spacing
  */
-.wp-block-post-template:not(.is-layout-grid) .wp-block-post + .wp-block-post {
+.wp-site-blocks .wp-block-post-template:not(.is-layout-grid) .wp-block-post + .wp-block-post {
 	margin-block-start: var(--spacer-40);
 }
 
@@ -17,7 +17,7 @@
  * width. The calculations subtract an extra pixel due to calc not enjoying our
  * use of clamped spacer variables.
  */
-.wp-block-post-template.is-layout-grid {
+.wp-site-blocks .wp-block-post-template.is-layout-grid {
 	--post-template-grid-template-columns: 1fr;
 	gap: var(--spacer-40);
 	grid-template-columns: var(--post-template-grid-template-columns);

--- a/wp-content/themes/core/blocks/core/querynoresults/Query_No_Results.php
+++ b/wp-content/themes/core/blocks/core/querynoresults/Query_No_Results.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Theme\blocks\core\querynoresults;
+
+use Tribe\Plugin\Blocks\Block_Base;
+
+class Query_No_Results extends Block_Base {
+
+	public function get_block_name(): string {
+		return 'core/query-no-results';
+	}
+
+	public function get_block_path(): string {
+		return 'core/querynoresults';
+	}
+
+}

--- a/wp-content/themes/core/blocks/core/querynoresults/index.js
+++ b/wp-content/themes/core/blocks/core/querynoresults/index.js
@@ -1,0 +1,5 @@
+/**
+ * Scripts specific to this block
+ */
+
+import './style.pcss';

--- a/wp-content/themes/core/blocks/core/querynoresults/style.pcss
+++ b/wp-content/themes/core/blocks/core/querynoresults/style.pcss
@@ -7,6 +7,7 @@
 	/**
 	* Hack to get around query block displaying no results blocks
 	* on final page of results
+	* @see https://github.com/WordPress/gutenberg/pull/53772
 	*/
 	.search-results & {
 		display: none;

--- a/wp-content/themes/core/blocks/core/querynoresults/style.pcss
+++ b/wp-content/themes/core/blocks/core/querynoresults/style.pcss
@@ -1,0 +1,14 @@
+/**
+ * Styles specific to this block
+ */
+
+.wp-block-query-no-results {
+
+	/**
+	* Hack to get around query block displaying no results blocks
+	* on final page of results
+	*/
+	.search-results & {
+		display: none;
+	}
+}

--- a/wp-content/themes/core/blocks/core/querypagination/style.pcss
+++ b/wp-content/themes/core/blocks/core/querypagination/style.pcss
@@ -5,6 +5,7 @@
 .wp-block-query-pagination {
 	align-items: center;
 	gap: 0 24px;
+	margin-top: var(--spacer-40);
 
 	& a {
 		color: var(--color-black);

--- a/wp-content/themes/core/blocks/tribe/query-results-count/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/style.pcss
@@ -9,6 +9,10 @@
 
 	@mixin t-body;
 
+	> p {
+		margin-top: 0;
+	}
+
 	.search-term {
 		font-weight: 700;
 	}

--- a/wp-content/themes/core/templates/archive.html
+++ b/wp-content/themes/core/templates/archive.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query-title {"type":"archive","textAlign":"center","showPrefix":false,"align":"wide","style":{"spacing":{"margin":{"top":"0"}}}} /-->
+<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query-title {"type":"archive","textAlign":"center","showPrefix":false,"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} /-->
 
 <!-- wp:query {"queryId":0,"query":{"perPage":18,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"align":"wide"} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->

--- a/wp-content/themes/core/templates/index.html
+++ b/wp-content/themes/core/templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":1,"align":"wide","style":{"spacing":{"margin":{"top":"0"}}}} -->
-<h1 class="wp-block-heading alignwide has-text-align-center" style="margin-top:0">Posts Title - Editable in FSE</h1>
+<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":1,"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+<h1 class="wp-block-heading alignwide has-text-align-center" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">Posts Title - Editable in FSE</h1>
 <!-- /wp:heading -->
 
 <!-- wp:query {"queryId":0,"query":{"perPage":18,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"align":"wide"} -->

--- a/wp-content/themes/core/templates/search.html
+++ b/wp-content/themes/core/templates/search.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"top":"0"}}}} -->
-<h1 class="wp-block-heading has-text-align-center" style="margin-top:0">Search</h1>
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+<h1 class="wp-block-heading has-text-align-center" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--30)">Search</h1>
 <!-- /wp:heading -->
 
 <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /--></div>
@@ -28,8 +28,8 @@
 <!-- /wp:post-template -->
 
 <!-- wp:query-no-results -->
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Your search query returned no results. Try another search term.</p>
+<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"0"}}}} -->
+<p class="has-text-align-center" style="margin-top:0">Your search query returned no results. Try another search term.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer {"height":"50px"} -->


### PR DESCRIPTION
## What does this do/fix?

- Adds "Query No Results" block support so that we can add a "hack" to remove the no results block on the search template where we actually have results but it's the last page (thanks for finding this one @jamiepaul)
- Moves post card responsive to container queries, which should make the responsive for these cards feel a lot better.
- Adds explanations to the list block selectors
- The post template block was affected negatively by the asset enqueuing update. The selectors weren't specific enough to override some WP styling. I've added a `.wp-site-blocks` prefix to these selectors. @dpellenwood, I was incorrect on the list note from the other PR. `wp-site-blocks` is a child element of `editor-styles-wrapper`, so we _are_ able to also use that as a selector in the editor. The list block styles weren't affected by this change, however, as those selectors still work correctly in the editor & on the FE.
- Added some style margin to the top of the pagination block - margin settings are not available on this block.
- Since we added global margins to paragraphs, there were a few places where paragraphs were now getting spacing where they shouldn't. I've removed this extra spacing from templates & style files where it seemed reasonable to do so.
- Both archive templates (`archive.html` & `index.html`) lost the bottom margin on their headlines. I've added this back into the templates.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-34)
