### PR TITLE
[FEATURE] Gloablly Enqueued Core Block Styles

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Block_Base.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Base.php
@@ -90,7 +90,7 @@ abstract class Block_Base {
 			wp_enqueue_style(
 				$this->get_block_handle(),
 				$src,
-				$this->get_block_dependencies(),
+				$args['dependencies'] ?? [],
 				$args['version'] ?? false,
 				'all'
 			);

--- a/wp-content/plugins/core/src/Blocks/Block_Base.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Base.php
@@ -79,14 +79,17 @@ abstract class Block_Base {
 		$path     = $this->get_block_path();
 		$src_path = get_theme_file_path( "dist/blocks/$path/style-index.css" );
 		$src      = get_theme_file_uri( "dist/blocks/$path/style-index.css" );
+		$args     = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/index.asset.php" ) );
 
 		if ( ! file_exists( $src_path ) ) {
 			return;
 		}
 
-		if ( $this->global_enqueue ) {
-			$args = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/index.asset.php" ) );
+		// Add the style in the editor
+		add_editor_style( $src );
 
+		if ( $this->global_enqueue && ! is_admin() ) {
+			// Enqueue the style unconditionally on the public site
 			wp_enqueue_style(
 				$this->get_block_handle(),
 				$src,
@@ -94,11 +97,12 @@ abstract class Block_Base {
 				$args['version'] ?? false,
 				'all'
 			);
-		} else {
-			wp_add_inline_style( $handle, file_get_contents( $src_path ) );
+
+			return;
 		}
 
-		add_editor_style( $src );
+		// Conditionally inline the style for the public site
+		wp_add_inline_style( $handle, file_get_contents( $src_path ) );
 	}
 
 	/**

--- a/wp-content/plugins/core/src/Blocks/Block_Base.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Base.php
@@ -10,6 +10,7 @@ abstract class Block_Base {
 
 	protected string $assets_path;
 	protected string $assets_path_uri;
+	protected bool $global_enqueue = false;
 
 	abstract public function get_block_name(): string;
 
@@ -83,7 +84,20 @@ abstract class Block_Base {
 			return;
 		}
 
-		wp_add_inline_style( $handle, file_get_contents( $src_path ) );
+		if ( $this->global_enqueue ) {
+			$args = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/index.asset.php" ) );
+
+			wp_enqueue_style(
+				$this->get_block_handle(),
+				$src,
+				$this->get_block_dependencies(),
+				$args['version'] ?? false,
+				'all'
+			);
+		} else {
+			wp_add_inline_style( $handle, file_get_contents( $src_path ) );
+		}
+
 		add_editor_style( $src );
 	}
 

--- a/wp-content/themes/core/blocks/core/button/Button.php
+++ b/wp-content/themes/core/blocks/core/button/Button.php
@@ -6,8 +6,6 @@ use Tribe\Plugin\Blocks\Block_Base;
 
 class Button extends Block_Base {
 
-	protected bool $global_enqueue = true;
-
 	public function get_block_name(): string {
 		return 'core/button';
 	}

--- a/wp-content/themes/core/blocks/core/button/Button.php
+++ b/wp-content/themes/core/blocks/core/button/Button.php
@@ -6,6 +6,8 @@ use Tribe\Plugin\Blocks\Block_Base;
 
 class Button extends Block_Base {
 
+	protected bool $global_enqueue = true;
+
 	public function get_block_name(): string {
 		return 'core/button';
 	}


### PR DESCRIPTION
## What does this do/fix?

- adds `$global_enqueue` variable to the `Block_Base` class to allow core block styles to be enqueued globally. 
- this solves some issues we've seen on a few projects where we've needed some core block custom styling to be available globally.
- currently I believe this is an issue where were duplicating core block markup for use in places where blocks aren't used. If we're not using the actual block, the assets don't get enqueued
- without this option, our only other option is duplicating styling rules
- @JMRhodes initially implemented this on QCHI. I also believe there _was_ a need on Comic-con for this (I'm not sure if there still is or not, but I believe they are duplicating styles in a few places to remedy). cc @Vinsanity @LayaTaal 
