### PR TITLE
[FIX] Primary Term Trait

### DIFF
--- a/wp-content/plugins/core/src/Post_Types/Post/Post.php
+++ b/wp-content/plugins/core/src/Post_Types/Post/Post.php
@@ -3,8 +3,11 @@
 namespace Tribe\Plugin\Post_Types\Post;
 
 use Tribe\Libs\Post_Type\Post_Object;
+use Tribe\Plugin\Templates\Traits\Primary_Term;
 
 class Post extends Post_Object {
+
+	use Primary_Term;
 
 	public const NAME = 'post';
 

--- a/wp-content/plugins/core/src/Templates/Traits/Primary_Term.php
+++ b/wp-content/plugins/core/src/Templates/Traits/Primary_Term.php
@@ -21,7 +21,7 @@ trait Primary_Term {
 
 		// RankMath SEO Enabled
 		if ( $this->has_rank_math() ) {
-			$primary_term_id = get_post_meta( "rank_math_primary_{$taxonomy}", $post_id );
+			$primary_term_id = get_post_meta( $post_id, "rank_math_primary_{$taxonomy}", true );
 		}
 
 		// No Yoast fallback


### PR DESCRIPTION
## What does this do/fix?

- adds `Primary_Term` trait to `Post` class so it can be used if necessary.
- fixes small issue with RankMath `get_post_meta` call in `Primary_Term` trait.
