### PR TITLE
PHPCS Cleanup

### DIFF
--- a/.deploy/config/local-config-dokku.php
+++ b/.deploy/config/local-config-dokku.php
@@ -9,10 +9,8 @@
  *
  * @param string $key
  * @param string $default
- *
- * @return string|bool
  */
-function fromenv( string $key, mixed $default = null ) {
+function fromenv( string $key, mixed $default = null ): string|array|bool {
 	$value = getenv( $key );
 	if ( $value === false ) {
 		$value = $default;

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,6 @@
 	},
 	"require": {
 		"php": "^8.0|^8.1",
-		"block-editor-custom-alignments/block-editor-custom-alignments": "*",
 		"composer/installers": "^2.2",
 		"gravityforms/gravityforms": "*",
 		"humanmade/s3-uploads": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da2ed3eaf3f1f3cde32644ff23675671",
+    "content-hash": "c3a80f6fc3836ee7b290191f73432a39",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -154,18 +154,6 @@
                 "source": "https://github.com/aws/aws-sdk-php/tree/3.280.0"
             },
             "time": "2023-08-30T18:19:33+00:00"
-        },
-        {
-            "name": "block-editor-custom-alignments/block-editor-custom-alignments",
-            "version": "1.0.6",
-            "dist": {
-                "type": "zip",
-                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
-            },
-            "require": {
-                "ffraenz/private-composer-installer": "^5.0"
-            },
-            "type": "wordpress-plugin"
         },
         {
             "name": "composer/ca-bundle",
@@ -6440,24 +6428,6 @@
             "homepage": "https://wordpress.org/plugins/limit-login-attempts-reloaded/"
         },
         {
-            "name": "wpackagist-plugin/redirection",
-            "version": "5.3.10",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/redirection/",
-                "reference": "tags/5.3.10"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/redirection.5.3.10.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/redirection/"
-        },
-        {
             "name": "wpackagist-plugin/safe-svg",
             "version": "2.2.0",
             "source": {
@@ -11859,5 +11829,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,7 @@
 	<!--  Update to the PHP version your production/local docker container runs on -->
 	<config name="testVersion" value="8.0" />
 	<!-- php -r 'echo PHP_VERSION_ID;' -->
-	<config name="php_version" value="70407" />
+	<config name="php_version" value="80118" />
 
 	<!-- Fix WordPress's terrible typing breaking PHPCS -->
 	<config name="minimum_supported_wp_version" value="6.0.2" />

--- a/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Admin_Assets_Enqueuer.php
@@ -77,7 +77,7 @@ class Admin_Assets_Enqueuer extends Assets_Enqueuer {
 					padding-top: 86px;
 				}
 			</style>',
-			$login_logo
+			esc_url( $login_logo )
 		);
 	}
 

--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -8,10 +8,7 @@ class Core {
 
 	public const PLUGIN_FILE = 'plugin.file';
 
-	/**
-	 * @var \Psr\Container\ContainerInterface|\Invoker\InvokerInterface|\DI\FactoryInterface
-	 */
-	private $container;
+	private \Psr\Container\ContainerInterface|\Invoker\InvokerInterface|\DI\FactoryInterface $container;
 
 	/**
 	 * @var string[] Names of classes implementing Definer_Interface.
@@ -56,10 +53,7 @@ class Core {
 		$this->init_container( $plugin_path );
 	}
 
-	/**
-	 * @return \Psr\Container\ContainerInterface|\Invoker\InvokerInterface|\DI\FactoryInterface
-	 */
-	public function container() {
+	public function container(): \Psr\Container\ContainerInterface|\Invoker\InvokerInterface|\DI\FactoryInterface {
 		return $this->container;
 	}
 

--- a/wp-content/themes/core/blocks/tribe/post-permalink/render.php
+++ b/wp-content/themes/core/blocks/tribe/post-permalink/render.php
@@ -3,6 +3,6 @@
 $post_permalink = get_the_permalink();
 ?>
 
-<div <?php echo get_block_wrapper_attributes(); ?>>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<span class="wp-block-tribe-post-permalink__label"><?php esc_html_e( $post_permalink, 'tribe' ); ?></span>
 </div>

--- a/wp-content/themes/core/blocks/tribe/post-type-name/render.php
+++ b/wp-content/themes/core/blocks/tribe/post-type-name/render.php
@@ -14,6 +14,6 @@ if ( ! $post_object ) {
 }
 ?>
 
-<div <?php echo get_block_wrapper_attributes(); ?>>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<span class="wp-block-tribe-post-type-name__label"><?php esc_html_e( $post_object->labels->singular_name, 'tribe' ); ?></span>
 </div>

--- a/wp-content/themes/core/blocks/tribe/post-type-name/render.php
+++ b/wp-content/themes/core/blocks/tribe/post-type-name/render.php
@@ -1,13 +1,13 @@
 <?php declare(strict_types=1);
 
 // this gets us the post type, but we really want the name
-$post_type = get_post_type();
+$block_post_type = get_post_type();
 
-if ( ! $post_type ) {
+if ( ! $block_post_type ) {
 	return;
 }
 
-$post_object = get_post_type_object( $post_type );
+$post_object = get_post_type_object( $block_post_type );
 
 if ( ! $post_object ) {
 	return;

--- a/wp-content/themes/core/blocks/tribe/query-results-count/render.php
+++ b/wp-content/themes/core/blocks/tribe/query-results-count/render.php
@@ -19,6 +19,6 @@ if ( $is_search ) {
 }
 ?>
 
-<div <?php echo get_block_wrapper_attributes(); ?>>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<p><?php echo wp_kses_post( $output ); ?></p>
 </div>

--- a/wp-content/themes/core/blocks/tribe/terms/render.php
+++ b/wp-content/themes/core/blocks/tribe/terms/render.php
@@ -10,24 +10,24 @@ use Tribe\Plugin\Blocks\Terms_Block;
  * @var \WP_Block $block          The instance of the WP_Block class that represents the block being rendered.
  */
 
-$terms_block = new Terms_Block( $attributes );
-$terms       = $terms_block->get_the_terms();
+$terms_block       = new Terms_Block( $attributes );
+$terms_block_terms = $terms_block->get_the_terms();
 
 echo '<div ' .  wp_kses_data( get_block_wrapper_attributes() ) . '>';
 
-if ( 0 === count( $terms ) ) {
+if ( 0 === count( $terms_block_terms ) ) {
 	echo '<!-- Terms block: No terms to list. -->';
 	echo '</div>';
 
 	return;
 }
 
-if ( count( $terms ) > 1 ) {
+if ( count( $terms_block_terms ) > 1 ) {
 	echo  '<ul class="wp-block-tribe-terms__list">';
 }
 
-foreach ( $terms as $term ) {
-	if ( count( $terms ) > 1 ) {
+foreach ( $terms_block_terms as $term ) {
+	if ( count( $terms_block_terms ) > 1 ) {
 		echo '<li class="wp-block-tribe-terms__term">';
 	}
 
@@ -36,7 +36,7 @@ foreach ( $terms as $term ) {
 	if ( $terms_block->display_as_links() ) {
 		echo sprintf(
 			'<a href="%s" class="wp-block-tribe-terms__link t-category">%s</a>',
-			esc_url( get_term_link( $term ) ),
+			esc_url( get_term_link( $term ) ?? '' ),
 			esc_html( $term->name )
 		);
 	} else {
@@ -48,12 +48,12 @@ foreach ( $terms as $term ) {
 
 	echo '</span>';
 
-	if ( count( $terms ) > 1 ) { // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+	if ( count( $terms_block_terms ) > 1 ) { // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
 		echo '</li>';
 	}
 }
 
-if ( count( $terms ) > 1 ) {
+if ( count( $terms_block_terms ) > 1 ) {
 	echo '</ul>';
 }
 

--- a/wp-content/themes/core/blocks/tribe/terms/render.php
+++ b/wp-content/themes/core/blocks/tribe/terms/render.php
@@ -13,7 +13,7 @@ use Tribe\Plugin\Blocks\Terms_Block;
 $terms_block = new Terms_Block( $attributes );
 $terms       = $terms_block->get_the_terms();
 
-echo '<div ' . get_block_wrapper_attributes() . '>';
+echo '<div ' .  wp_kses_data( get_block_wrapper_attributes() ) . '>';
 
 if ( 0 === count( $terms ) ) {
 	echo '<!-- Terms block: No terms to list. -->';


### PR DESCRIPTION
## What does this do/fix?

Upgrades default PHP Version for PHPCS to 8 to match our current minimum suggested PHP Version.
Adds escaping for `get_block_wrapper_attributes()` using `wp_kses_data()`.
Removes unused plugins from Composer.