### PR TITLE
WordPress 6.3.2 and Plugin Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2023.10]
+
+- Updated: WordPress Core update to 6.3.2
+- Updated: Disable Emojis to 1.7.6, Limit Login Attempts Reloaded to 2.25.25, RankMath to 1.0.203, ACF Pro to 6.2.1.1
+
 ## [2023.08]
 
 - Added: GTM4WP Plugin for handling Google Tag Manager.

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,21 @@
 		{
 			"type": "composer",
 			"url": "https://connect.advancedcustomfields.com"
+		},
+		{
+			"type": "package",
+			"package": {
+				"name": "block-editor-custom-alignments/block-editor-custom-alignments",
+				"version": "1.0.6",
+				"type": "wordpress-plugin",
+				"dist": {
+					"type": "zip",
+					"url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
+				},
+				"require": {
+					"ffraenz/private-composer-installer": "^5.0"
+				}
+			}
 		}
 	],
 	"require-dev": {
@@ -96,6 +111,7 @@
 	},
 	"require": {
 		"php": "^8.0|^8.1",
+		"block-editor-custom-alignments/block-editor-custom-alignments": "^1.0",
 		"composer/installers": "^2.2",
 		"gravityforms/gravityforms": "*",
 		"humanmade/s3-uploads": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 			"@php -r \"file_exists('local-config.php') || copy('local-config-sample.php', 'local-config.php');\"",
 			"@php -r \"file_exists('local-config.json') || copy('local-config-sample.json', 'local-config.json');\""
 		],
-		"setup-wordpress": "./vendor/bin/wp core download --version=6.3.1 --quiet --skip-content --force",
+		"setup-wordpress": "./vendor/bin/wp core download --version=6.3.2 --quiet --skip-content --force",
 		"post-root-package-install": [
 			"@setup-repo"
 		],
@@ -75,21 +75,6 @@
 		{
 			"type": "composer",
 			"url": "https://connect.advancedcustomfields.com"
-		},
-		{
-			"type": "package",
-			"package": {
-				"name": "block-editor-custom-alignments/block-editor-custom-alignments",
-				"version": "1.0.6",
-				"type": "wordpress-plugin",
-				"dist": {
-					"type": "zip",
-					"url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
-				},
-				"require": {
-					"ffraenz/private-composer-installer": "^5.0"
-				}
-			}
 		}
 	],
 	"require-dev": {
@@ -111,7 +96,6 @@
 	},
 	"require": {
 		"php": "^8.0|^8.1",
-		"block-editor-custom-alignments/block-editor-custom-alignments": "*",
 		"composer/installers": "^2.2",
 		"gravityforms/gravityforms": "*",
 		"humanmade/s3-uploads": "^3.0",
@@ -125,14 +109,14 @@
 		"vinkla/extended-acf": "^13.6",
 		"vlucas/phpdotenv": "^5.5",
 		"wp-cli/wp-cli-bundle": "^2.8",
-		"wpackagist-plugin/disable-emojis": "^1.7",
+		"wpackagist-plugin/disable-emojis": "1.7.6",
 		"wpackagist-plugin/duracelltomi-google-tag-manager": "1.18.1",
-		"wpackagist-plugin/limit-login-attempts-reloaded": "2.25.23",
+		"wpackagist-plugin/limit-login-attempts-reloaded": "2.25.25",
 		"wpackagist-plugin/safe-svg": "2.2.0",
-		"wpackagist-plugin/seo-by-rank-math": "^1.0",
+		"wpackagist-plugin/seo-by-rank-math": "1.0.203",
 		"wpackagist-plugin/user-switching": "^1.7",
 		"wpackagist-plugin/wp-tota11y": "^1.2",
-		"wpengine/advanced-custom-fields-pro": "6.2"
+		"wpengine/advanced-custom-fields-pro": "6.2.1.1"
 	},
 	"extra": {
 		"installer-paths": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da2ed3eaf3f1f3cde32644ff23675671",
+    "content-hash": "1190f1ec1f9d47a261c1cb1406950c3d",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -154,18 +154,6 @@
                 "source": "https://github.com/aws/aws-sdk-php/tree/3.280.0"
             },
             "time": "2023-08-30T18:19:33+00:00"
-        },
-        {
-            "name": "block-editor-custom-alignments/block-editor-custom-alignments",
-            "version": "1.0.6",
-            "dist": {
-                "type": "zip",
-                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
-            },
-            "require": {
-                "ffraenz/private-composer-installer": "^5.0"
-            },
-            "type": "wordpress-plugin"
         },
         {
             "name": "composer/ca-bundle",
@@ -6387,15 +6375,15 @@
         },
         {
             "name": "wpackagist-plugin/disable-emojis",
-            "version": "1.7.5",
+            "version": "1.7.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/disable-emojis/",
-                "reference": "tags/1.7.5"
+                "reference": "tags/1.7.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/disable-emojis.1.7.5.zip"
+                "url": "https://downloads.wordpress.org/plugin/disable-emojis.1.7.6.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -6423,39 +6411,21 @@
         },
         {
             "name": "wpackagist-plugin/limit-login-attempts-reloaded",
-            "version": "2.25.23",
+            "version": "2.25.25",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/limit-login-attempts-reloaded/",
-                "reference": "tags/2.25.23"
+                "reference": "tags/2.25.25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/limit-login-attempts-reloaded.2.25.23.zip"
+                "url": "https://downloads.wordpress.org/plugin/limit-login-attempts-reloaded.2.25.25.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/limit-login-attempts-reloaded/"
-        },
-        {
-            "name": "wpackagist-plugin/redirection",
-            "version": "5.3.10",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/redirection/",
-                "reference": "tags/5.3.10"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/redirection.5.3.10.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/redirection/"
         },
         {
             "name": "wpackagist-plugin/safe-svg",
@@ -6477,15 +6447,15 @@
         },
         {
             "name": "wpackagist-plugin/seo-by-rank-math",
-            "version": "1.0.122",
+            "version": "1.0.203",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/seo-by-rank-math/",
-                "reference": "tags/1.0.122"
+                "reference": "tags/1.0.203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/seo-by-rank-math.1.0.122.zip"
+                "url": "https://downloads.wordpress.org/plugin/seo-by-rank-math.1.0.203.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -6531,10 +6501,10 @@
         },
         {
             "name": "wpengine/advanced-custom-fields-pro",
-            "version": "6.2.0",
+            "version": "6.2.1.1",
             "dist": {
                 "type": "zip",
-                "url": "https://connect.advancedcustomfields.com/v2/plugins/composer_download?p=pro&t=6.2.0"
+                "url": "https://connect.advancedcustomfields.com/v2/plugins/composer_download?p=pro&t=6.2.1.1"
             },
             "require": {
                 "composer/installers": "~1.0 || ~2.0"
@@ -11859,5 +11829,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3a80f6fc3836ee7b290191f73432a39",
+    "content-hash": "9618499769d40cbea4f912c52cf84cf5",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -154,6 +154,18 @@
                 "source": "https://github.com/aws/aws-sdk-php/tree/3.280.0"
             },
             "time": "2023-08-30T18:19:33+00:00"
+        },
+        {
+            "name": "block-editor-custom-alignments/block-editor-custom-alignments",
+            "version": "1.0.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.0.6/block-editor-custom-alignments.1.0.6.zip"
+            },
+            "require": {
+                "ffraenz/private-composer-installer": "^5.0"
+            },
+            "type": "wordpress-plugin"
         },
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
## What does this do/fix?

Updates WordPress Core from 6.3.1 to 6.3.2
Updates the following plugins:
- advanced-custom-fields-pro to 6.2.1.1
- disable-emojis to 1.7.6
- limit-login-attempts-reloaded to 2.25.25
- seo-by-rank-math to 1.0.203
