### PR TITLE
Adds Lighthouse CI GitHub Action

### DIFF
--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,0 +1,35 @@
+{
+    "ci": {
+        "assert": {
+            "assertions": {
+                "categories:performance": [
+                    "warn", {
+                        "aggregationMethod": "optimistic",
+                        "minScore": 0.8
+                    }
+                ],
+                "categories:accessibility": [
+                    "error", {
+                        "aggregationMethod": "optimistic",
+                        "minScore": 0.9
+                    }
+                ],
+                "categories:seo": [
+                    "warn", {
+                        "aggregationMethod": "optimistic",
+                        "minScore": 0.8
+                    }
+                ],
+                "categories:best-practices": [
+                    "warn", {
+                        "aggregationMethod": "optimistic",
+                        "minScore": 0.8
+                    }
+                ]
+            }
+        },
+        "collect": {
+            "numberOfRuns": 5
+        }
+    }
+}

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,17 @@
+name: Lighthouse CI
+on:
+  workflow_dispatch:
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v10
+        with:
+          urls: |
+            https://moose-dev.d1.moderntribe.qa/?secret=1
+          # budgetPath: .github/lighthouse/budget.json
+          uploadArtifacts: true # save results as an action artifacts
+          temporaryPublicStorage: false # upload lighthouse report to the temporary storage
+          configPath: .github/lighthouse/lighthouserc.json


### PR DESCRIPTION
Due to a limitation in GitHub actions, this will need to be merged to the main branch before running the workflow as a full test.

## What does this do/fix?

This PR creates a Lighthouse CI Action that can be run via a workflow_dispatch. When the workflow runs, it will query one to many (line separated) of the URLs listed in the `urls` param.  The results will trigger an error or warning in the action UI based on the config settings in the `lighthouserc.json` file.  These settings should be customized for each production site based on the current performance. The full report is also added to the action artifacts, which can be disabled by changing the `uploadArtifacts` param to false.

This action aims to eventually run after deployments to test the site and trigger notifications if there are any performance, accessibility, SEO, or best practice degradations. 

