### PR TITLE
[MOOSE-67]: Exclude only the root node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ local-xdebuginfo.php
 .env
 /wp/
 .phpstan-cache/
-node_modules/
+/node_modules/
 auth.json
 
 wp-content/themes/core/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Chore: WordPress 6.4.1 Update
 - Chore: Plugin updates - advanced-custom-fields-pro:6.2.2, limit-login-attempts-reloaded:2.25.26, seo-by-rank-math:1.0.205, safe-svg:2.2.1
+- Updated: Only exclude the node_modules folder if it is in the root of the project.
 
 ## [2023.10]
 


### PR DESCRIPTION
## What does this do/fix?

Updates the .gitignore to exclude only the root folder node_modules and not all the node_modules folders it finds in the project.  


**Jira Ticket:**  [MOOSE-67](https://moderntribe.atlassian.net/browse/MOOSE-67)



[MOOSE-67]: https://moderntribe.atlassian.net/browse/MOOSE-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ