### PR TITLE
Adds override for triggering xdebug with using WP-CLI

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -22,7 +22,7 @@ tooling:
   xdebug-on:
     service: appserver
     description: Enable xdebug for nginx.
-    cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && echo "Enabling xdebug enabled"
+    cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && echo "Xdebug enabled"
     user: root
   xdebug-off:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -8,6 +8,10 @@ config:
   xdebug: true
   memcached: true
 services:
+  appserver:
+    overrides:
+      environment:
+        - XDEBUG_TRIGGER=1
   mailhog:
     type: mailhog
     portforward: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2023.12]
+
+- Added: Xdebug support for WP Cli commands.
+
 ## [2023.11]
 
 - Chore: WordPress 6.4.1 Update


### PR DESCRIPTION
## What does this do/fix?

Adds the ability to trigger xdebug with wp-cli when using lando. Requires `lando rebuild` to go into effect on current projects. 