### PR TITLE
[MOOSE-81] Update ACF Block `render_template` Function

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Block_Registrar.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Registrar.php
@@ -25,11 +25,15 @@ class Block_Registrar {
 	}
 
 	/**
-	 * @param array $args
+	 * @param array          $block      The block attributes.
+	 * @param string         $content    The block content.
+	 * @param bool           $is_preview Whether the block is being rendered for editing preview.
+	 * @param int            $post_id    The current post being edited or viewed.
+	 * @param \WP_Block|null $wp_block   The block instance (since WP 5.5).
 	 */
-	public function render_template( array $args ): void {
-		$template = $args['render_template'];
-		$path     = str_replace( 'dist/blocks/', 'blocks/', $args['path'] );
+	public function render_template( array $block, string $content = '', bool $is_preview = false, int $post_id = 0, ?\WP_Block $wp_block = null ): void {
+		$template = $block['render_template'];
+		$path     = str_replace( 'dist/blocks/', 'blocks/', $block['path'] );
 
 		if ( ! file_exists( "$path/$template" ) ) {
 			return;


### PR DESCRIPTION
## What does this do/fix?

- updates ACF block `render_template` functions to provide ACF blocks with more useful information that we weren't providing previously

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-81)
