### PR TITLE
[MOOSE-95]: update asset enqueuing for global editor assets

### DIFF
--- a/wp-content/plugins/core/src/Assets/Editor_Assets_Enqueuer.php
+++ b/wp-content/plugins/core/src/Assets/Editor_Assets_Enqueuer.php
@@ -11,13 +11,7 @@ class Editor_Assets_Enqueuer extends Assets_Enqueuer {
 	public function register(): void {
 		$args = $this->get_asset_file_args( $this->assets_path . self::ASSETS_FILE );
 
-		wp_enqueue_style(
-			self::EDITOR,
-			$this->assets_path_uri . self::EDITOR_FILE_NAME . '.css',
-			[],
-			$args['version'] ?? false,
-			'all',
-		);
+		add_editor_style( $this->assets_path_uri . self::EDITOR_FILE_NAME . '.css', );
 
 		wp_enqueue_script(
 			self::EDITOR,


### PR DESCRIPTION
## What does this do/fix?

- updates asset queuing for global editor styles to use `add_editor_style` instead of `wp_enqueue_style`. This was likely why our global styles were not showing in the site editor.
- @Vinsanity just checking here that this was your fix to this issue we were having?

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-95)

Screenshots/video:
- Global styles seem to now be loading within site editor: http://p.tri.be/i/wm2w2W
