### PR TITLE
[MOOSE-111] Editor Title Bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2024.03]
+- Added: Styling for editor title bar (http://p.tri.be/i/Dszjax) [MOOSE-111]
+
 ## [2024.02]
 - Chore: WordPress 6.4.3 Update
 - Chore: Plugin updates: advanced-custom-fields-pro:6.2.6, gravityforms:2.8.3, duracelltomi-google-tag-manager:1.20,, limit-login-attempts-reloaded:2.26.2,seo-by-rank-math:1.0.212

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 ## [2024.03]
-- Added: Styling for editor title bar (http://p.tri.be/i/Dszjax) [[MOOSE-111]](https://moderntribe.atlassian.net/browse/MOOSE-111)
+- Added: Styling for editor title bar (http://p.tri.be/i/Dszjax). [[MOOSE-111]](https://moderntribe.atlassian.net/browse/MOOSE-111)
+- Added: Allow `view.js` files for blocks. [[MOOSE-86]](https://moderntribe.atlassian.net/browse/MOOSE-86)
+- Changed: `render_template` function for ACF blocks should now properly pass in all block variables. [[MOOSE-81]](https://moderntribe.atlassian.net/browse/MOOSE-81)
 
 ## [2024.02]
 - Chore: WordPress 6.4.3 Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 ## [2024.03]
-- Added: Styling for editor title bar (http://p.tri.be/i/Dszjax) [MOOSE-111]
+- Added: Styling for editor title bar (http://p.tri.be/i/Dszjax) [[MOOSE-111]](https://moderntribe.atlassian.net/browse/MOOSE-111)
 
 ## [2024.02]
 - Chore: WordPress 6.4.3 Update

--- a/wp-content/themes/core/assets/pcss/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/editor.pcss
@@ -11,6 +11,7 @@
 /* Global Theme Editor Styles */
 @import "layout/default.pcss";
 @import "global/reset.pcss";
+@import "global/editor.pcss";
 @import "typography/anchors.pcss";
 
 /* Patterns */

--- a/wp-content/themes/core/assets/pcss/global/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/global/editor.pcss
@@ -1,0 +1,32 @@
+/* -------------------------------------------------------------------------
+ *
+ * Global - Editor
+ *
+ * ------------------------------------------------------------------------- */
+
+/* handle styling the editor "title bar" */
+.edit-post-visual-editor__post-title-wrapper {
+
+	.wp-block-post-title {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: var(--spacer-10);
+
+		/* we're defaulting to a different content width here to further
+		   differentiate between this title & the other blocks */
+		max-width: var(--grid-max-width);
+		margin-top: 0;
+		padding: var(--spacer-20) var(--spacer-30);
+		border: 1px solid var(--color-black);
+		border-left: 6px solid var(--color-black);
+
+		/* add pseudo element to display field label */
+		&::before {
+
+			@mixin t-body-small;
+			content: "Page Title";
+			color: var(--color-neutral-50);
+		}
+	}
+}

--- a/wp-content/themes/core/assets/pcss/global/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/global/editor.pcss
@@ -6,6 +6,11 @@
 
 /* handle styling the editor "title bar" */
 .edit-post-visual-editor__post-title-wrapper {
+	width: 100% !important;
+	margin-top: 0 !important;
+	padding-top: var(--spacer-40);
+	padding-bottom: var(--spacer-40);
+	background-color: var(--color-neutral-20);
 
 	.wp-block-post-title {
 		display: flex;
@@ -18,15 +23,16 @@
 		max-width: var(--grid-max-width);
 		margin-top: 0;
 		padding: var(--spacer-20) var(--spacer-30);
-		border: 1px solid var(--color-black);
-		border-left: 6px solid var(--color-black);
+		border: 1px solid var(--color-neutral-60);
+		border-left: 6px solid var(--color-neutral-60);
+		background-color: var(--color-white);
 
 		/* add pseudo element to display field label */
 		&::before {
 
-			@mixin t-body-small;
+			@mixin t-body;
 			content: "Page Title";
-			color: var(--color-neutral-50);
+			color: var(--color-neutral-60);
 		}
 	}
 }


### PR DESCRIPTION
## What does this do/fix?

- adds styling to the WP title bar to differentiate it from the other blocks on the page

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-111)

Screenshots/video:
- Old: http://p.tri.be/i/o4R4w5
- New: http://p.tri.be/i/KlYSKe
