### PR TITLE
[FIX] Terms Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 ## [2024.03]
+- Fixed: Fixed an issue with the Terms block where if a post ID wasn't provided it would error out. [Panopto Slack thread.](https://tribe.slack.com/archives/C061UC7B2F9/p1710250320818599)
 - Added: Styling for editor title bar (http://p.tri.be/i/Dszjax). [[MOOSE-111]](https://moderntribe.atlassian.net/browse/MOOSE-111)
 - Added: Allow `view.js` files for blocks. [[MOOSE-86]](https://moderntribe.atlassian.net/browse/MOOSE-86)
 - Changed: `render_template` function for ACF blocks should now properly pass in all block variables. [[MOOSE-81]](https://moderntribe.atlassian.net/browse/MOOSE-81)

--- a/wp-content/plugins/core/src/Blocks/Terms_Block.php
+++ b/wp-content/plugins/core/src/Blocks/Terms_Block.php
@@ -27,13 +27,19 @@ class Terms_Block {
 	 * @return \WP_Term[]
 	 */
 	public function get_the_terms(): array {
+		$post_id = get_the_ID();
+
+		if ( ! $post_id ) {
+			return $this->terms;
+		}
+
 		if ( $this->only_primary_term ) {
-			$term = $this->get_primary_term( get_the_ID(), $this->taxonomy );
+			$term = $this->get_primary_term( $post_id, $this->taxonomy );
 			if ( $term ) {
 				$this->terms[] = $term;
 			}
 		} else {
-			$terms = get_the_terms( get_the_ID(), $this->taxonomy );
+			$terms = get_the_terms( $post_id, $this->taxonomy );
 			if ( $terms && ! is_wp_error( $terms ) ) {
 				$this->terms = $terms;
 			}

--- a/wp-content/themes/core/blocks/tribe/terms/block.json
+++ b/wp-content/themes/core/blocks/tribe/terms/block.json
@@ -16,13 +16,16 @@
 	},
 	"attributes": {
 		"taxonomyToUse": {
-			"type": "string"
+			"type": "string",
+			"default": "category"
 		},
 		"onlyPrimaryTerm": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": false
 		},
 		"hasLinks": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"styles": [ { "name": "pills", "label": "Pills" } ],

--- a/wp-content/themes/core/blocks/tribe/terms/edit.js
+++ b/wp-content/themes/core/blocks/tribe/terms/edit.js
@@ -61,12 +61,16 @@ export default function Edit( {
 									taxonomyToUse: newValue,
 								} );
 							} }
-							options={ taxonomies.map( ( taxonomy ) => {
-								return {
-									label: taxonomy.name,
-									value: taxonomy.slug,
-								};
-							} ) }
+							options={
+								taxonomies
+									? taxonomies.map( ( taxonomy ) => {
+											return {
+												label: taxonomy.name,
+												value: taxonomy.slug,
+											};
+									  } )
+									: []
+							}
 						/>
 						<ToggleControl
 							label={ __(


### PR DESCRIPTION
## What does this do/fix?

- fixes issue where the Terms block would error when no post ID was provided to it
- sets defaults for attributes in the Terms block - should prevent any "missing attribute" issues
- since the `taxonomies` array is gathered by an async request, we should be checking if it exists before we loop over nothing.

## QA

Links to relevant issues
- [Link to Panopto Slack thread](https://tribe.slack.com/archives/C061UC7B2F9/p1710250320818599)
