### PR TITLE
[MOOSE-84] Layout Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2024.03]
+- Fixed: Fixed an issue with the Terms block where if a post ID wasn't provided it would error out. [Panopto Slack thread.](https://tribe.slack.com/archives/C061UC7B2F9/p1710250320818599)
+- Added: Styling for editor title bar (http://p.tri.be/i/Dszjax). [[MOOSE-111]](https://moderntribe.atlassian.net/browse/MOOSE-111)
+- Added: Allow `view.js` files for blocks. [[MOOSE-86]](https://moderntribe.atlassian.net/browse/MOOSE-86)
+- Changed: `render_template` function for ACF blocks should now properly pass in all block variables. [[MOOSE-81]](https://moderntribe.atlassian.net/browse/MOOSE-81)
+- Changed: Layout styles are now properly separated between FE & editor. [[MOOSE-84]](https://moderntribe.atlassian.net/browse/MOOSE-84)
+- Changed: `theme.json` now contains static widths for content and wide widths. [[MOOSE-84]](https://moderntribe.atlassian.net/browse/MOOSE-84)
+- Added: `theme.json` now contains a new static "grid" width. [[MOOSE-84]](https://moderntribe.atlassian.net/browse/MOOSE-84)
+
 ## [2024.02]
 - Chore: WordPress 6.4.3 Update
 - Chore: Plugin updates: advanced-custom-fields-pro:6.2.6, gravityforms:2.8.3, duracelltomi-google-tag-manager:1.20,, limit-login-attempts-reloaded:2.26.2,seo-by-rank-math:1.0.212

--- a/wp-content/themes/core/assets/pcss/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/editor.pcss
@@ -10,6 +10,7 @@
 
 /* Global Theme Editor Styles */
 @import "layout/default.pcss";
+@import "layout/editor.pcss";
 @import "global/reset.pcss";
 @import "typography/anchors.pcss";
 

--- a/wp-content/themes/core/assets/pcss/layout/default.pcss
+++ b/wp-content/themes/core/assets/pcss/layout/default.pcss
@@ -25,8 +25,7 @@
  *
  * Screenshot: http://p.tri.be/i/oaIM0F
  */
-.has-global-padding > .alignfull:where(.has-global-padding) > :where(:not(.alignfull):not(.alignwide)),
-:is(.editor-styles-wrapper) .has-global-padding > .alignfull:where(.has-global-padding) > :where(:not(.alignfull):not(.alignwide)) {
+.has-global-padding > .alignfull:where(.has-global-padding) > :where(:not(.alignfull):not(.alignwide)) {
 	padding-right: var(--wp--style--root--padding-right);
 	padding-left: var(--wp--style--root--padding-left);
 	max-width: calc(var(--wp--style--global--content-size) + var(--wp--style--root--padding-left) * 2);
@@ -34,55 +33,20 @@
 
 /* -------------------------------------------------------------------------
  *
- * Layout: Align Wide
- *
- * Adjustments for fluid value in theme.json settings.layout.wideSize
+ * Layout: Align Wide & Grid
  *
  * ------------------------------------------------------------------------- */
 
 /*
- * CASE: settings.layout.wideSize = fluid value
+ * CASE: Double global padding selectors with alignwide / aligngrid children
  *
- * Max-width of blocks aligned wide should not account for grid margin
- * when nested in .has-global-padding because the container applies
- * grid margin as padding.
+ * WP styles remove padding from blocks nested in .has-global-padding.alignfull.
  *
- * Example: Top level Group block set to align wide should get a default
- * max-width of 100% because the top level already has global padding and
- * if we kept it, it would double the left/right spacing.
- *
- * Screenshot: http://p.tri.be/i/pV2gSJ
+ * Padding is added back to prevent alignwide/aligngrid from bumping
+ * up to the viewport edge.
  */
-.has-global-padding.is-layout-constrained > .alignwide,
-:is(.editor-styles-wrapper) .is-root-container.has-global-padding.is-layout-constrained > .alignwide {
-	max-width: 100%;
-}
-
-/*
- * CASE: settings.layout.wideSize = fluid value
- *
- * Max-width of blocks aligned wide nested inside two .has-global-padding
- * containers need to re-account for grid-margin.
- *
- * Example: Top level Columns block aligned wide inside Group block aligned full
- * should get our default wide size again because the Group block no longer has
- * padding.
- *
- * Screenshot (padding removed from alignfull element): http://p.tri.be/i/hfP3Fj
- * Screenshot (alignwide element reset): http://p.tri.be/i/Z86h5E
- */
-.has-global-padding :is(.has-global-padding) > .alignwide,
-:is(.editor-styles-wrapper) .has-global-padding :is(.has-global-padding) > .alignwide {
-	max-width: var(--wp--style--global--wide-size);
-}
-
-/*
- * Previously to this change, adding a full width pattern to the bottom
- * of a page would force the user to have to use "Insert After" functions
- * to add a block below.
- * This adds space for clicking at the bottom of the
- * .editor-styles-wrapper element and only appears in the admin editor.
- */
-:is(.editor-styles-wrapper) {
-	padding-bottom: 40vh;
+.has-global-padding > .alignfull:where(.has-global-padding):has(.alignwide),
+.has-global-padding > .alignfull:where(.has-global-padding):has(.aligngrid) {
+	padding-right: var(--wp--style--root--padding-right);
+	padding-left: var(--wp--style--root--padding-left);
 }

--- a/wp-content/themes/core/assets/pcss/layout/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/layout/editor.pcss
@@ -1,0 +1,37 @@
+/* -------------------------------------------------------------------------
+ *
+ * Layouts
+ *
+ * ------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------
+ *
+ * Layout: Align None (Content Width)
+ *
+ * Adjustments for content width blocks nested inside alignfull container blocks
+ * For blocks w/ align none nested inside container block with alignfull and
+ * constrained layout.
+ *
+ * ------------------------------------------------------------------------- */
+
+/* important added to override WP's editor stylesheet */
+.has-global-padding > .alignfull:where(.has-global-padding) > :where(:not(.alignfull):not(.alignwide):not(.aligngrid)) {
+	max-width: calc(var(--wp--style--global--content-size) + var(--wp--style--root--padding-left) * 2) !important;
+}
+
+/* -------------------------------------------------------------------------
+ *
+ * Editor Fixes
+ *
+ * ------------------------------------------------------------------------- */
+
+/*
+ * Previously to this change, adding a full width pattern to the bottom
+ * of a page would force the user to have to use "Insert After" functions
+ * to add a block below.
+ * This adds space for clicking at the bottom of the
+ * .editor-styles-wrapper element and only appears in the admin editor.
+ */
+:is(.editor-styles-wrapper) {
+	padding-bottom: 40vh;
+}

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -106,9 +106,19 @@
 			}
 		},
 		"layout": {
-			"contentSize": "640px",
-			"wideSize": "calc(100% - var(--wp--custom--spacing--grid-margin) * 2)"
+			"contentSize": "840px",
+			"wideSize": "1136px"
 		},
+		"_experimentalLayout": [
+			{
+				"name": "Grid",
+				"slug": "grid",
+				"icon": "M5 9v6h14V9H5zm11-4.8H8v1.5h8V4.2zM8 19.8h8v-1.5H8v1.5z",
+				"width": "1680px",
+				"textdomain": "tribe"
+			}
+		],
+		"_experimentalLayoutSorting": true,
 		"useRootPaddingAwareAlignments": true,
 		"spacing": {
 			"margin": true,


### PR DESCRIPTION
## What does this do/fix?

- migrates layout updates from Panopto (and a few other projects) to properly split FE / editor layout styling
- moves to using static values for content, wide, and (added) grid width alignment settings

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-84)
