### PR TITLE
[MOOSE-140] Updates: browserlist supported browser & npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@csstools/postcss-global-data": "^2.1.0",
-				"@wordpress/create-block": "^4.46.0",
-				"@wordpress/scripts": "^28.3.0",
+				"@csstools/postcss-global-data": "^3.0.0",
+				"@wordpress/create-block": "^4.48.0",
+				"@wordpress/scripts": "^28.5.0",
 				"browser-sync": "^3.0.2",
 				"browser-sync-v3-webpack-plugin": "^0.1.0",
-				"cssnano": "^7.0.3",
+				"cssnano": "^7.0.5",
 				"fast-glob": "^3.3.1",
-				"lefthook": "^1.6.18",
+				"lefthook": "^1.7.12",
 				"postcss-import": "^16.1.0",
 				"postcss-inline-svg": "^6.0.0",
 				"postcss-mixins": "^10.0.1",
-				"postcss-preset-env": "^9.5.14",
+				"postcss-preset-env": "^10.0.0",
 				"webpack-remove-empty-scripts": "^1.0.4"
 			},
 			"engines": {
@@ -57,9 +57,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
-			"integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
+			"integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -67,22 +67,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
-			"integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+			"integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.9",
-				"@babel/helper-compilation-targets": "^7.24.8",
-				"@babel/helper-module-transforms": "^7.24.9",
-				"@babel/helpers": "^7.24.8",
-				"@babel/parser": "^7.24.8",
-				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.8",
-				"@babel/types": "^7.24.9",
+				"@babel/generator": "^7.25.0",
+				"@babel/helper-compilation-targets": "^7.25.2",
+				"@babel/helper-module-transforms": "^7.25.2",
+				"@babel/helpers": "^7.25.0",
+				"@babel/parser": "^7.25.0",
+				"@babel/template": "^7.25.0",
+				"@babel/traverse": "^7.25.2",
+				"@babel/types": "^7.25.2",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -108,9 +108,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.8.tgz",
-			"integrity": "sha512-nYAikI4XTGokU2QX7Jx+v4rxZKhKivaQaREZjuW3mrJrbdWJ5yUfohnoUULge+zEEaKjPYNxhoRgUKktjXtbwA==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz",
+			"integrity": "sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -137,13 +137,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.24.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
-			"integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
+			"integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.24.9",
+				"@babel/types": "^7.25.0",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -180,13 +180,13 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
-			"integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+			"integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.24.8",
+				"@babel/compat-data": "^7.25.2",
 				"@babel/helper-validator-option": "^7.24.8",
 				"browserslist": "^4.23.1",
 				"lru-cache": "^5.1.1",
@@ -207,20 +207,18 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.8.tgz",
-			"integrity": "sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
+			"integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
 				"@babel/helper-member-expression-to-functions": "^7.24.8",
 				"@babel/helper-optimise-call-expression": "^7.24.7",
-				"@babel/helper-replace-supers": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.25.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/traverse": "^7.25.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -241,9 +239,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.24.7.tgz",
-			"integrity": "sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.2.tgz",
+			"integrity": "sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -285,46 +283,6 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
@@ -354,17 +312,16 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
-			"integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+			"integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
 				"@babel/helper-module-imports": "^7.24.7",
 				"@babel/helper-simple-access": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7"
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/traverse": "^7.25.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -397,15 +354,15 @@
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.24.7.tgz",
-			"integrity": "sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
+			"integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-wrap-function": "^7.24.7"
+				"@babel/helper-wrap-function": "^7.25.0",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -415,15 +372,15 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
-			"integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+			"integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-member-expression-to-functions": "^7.24.7",
-				"@babel/helper-optimise-call-expression": "^7.24.7"
+				"@babel/helper-member-expression-to-functions": "^7.24.8",
+				"@babel/helper-optimise-call-expression": "^7.24.7",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -454,19 +411,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
 				"@babel/types": "^7.24.7"
 			},
 			"engines": {
@@ -504,30 +448,29 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.7.tgz",
-			"integrity": "sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
+			"integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/template": "^7.25.0",
+				"@babel/traverse": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-			"integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+			"integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.8"
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -628,11 +571,14 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
-			"integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
+			"version": "7.25.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
+			"integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.25.2"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -641,14 +587,30 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.7.tgz",
-			"integrity": "sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==",
+			"version": "7.25.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.3.tgz",
+			"integrity": "sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/traverse": "^7.25.3"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.0.tgz",
+			"integrity": "sha512-Bm4bH2qsX880b/3ziJ8KD711LT7z4u8CFudmjqle65AZj/HNUFhEf90dqYv6O86buWvSBmeQDjv0Tn2aF/bIBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -658,13 +620,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.7.tgz",
-			"integrity": "sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.0.tgz",
+			"integrity": "sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -692,14 +654,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.7.tgz",
-			"integrity": "sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.0.tgz",
+			"integrity": "sha512-tggFrk1AIShG/RUQbEwt2Tr/E+ObkfwrPjR6BjbRvsx24+PSjK8zrq0GWPNCjo8qpRx4DuJzlcvWJqlm+0h3kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1036,16 +998,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.7.tgz",
-			"integrity": "sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
+			"integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-remap-async-to-generator": "^7.24.7",
-				"@babel/plugin-syntax-async-generators": "^7.8.4"
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-remap-async-to-generator": "^7.25.0",
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1089,13 +1051,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
-			"integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
+			"integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1140,19 +1102,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.8.tgz",
-			"integrity": "sha512-VXy91c47uujj758ud9wx+OMgheXm4qJfyhj1P18YvlrQkNOSrwsteHk+EFS3OMGfhMhpZa0A+81eE7G4QC+3CA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
+			"integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"@babel/helper-compilation-targets": "^7.24.8",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
 				"@babel/helper-plugin-utils": "^7.24.8",
-				"@babel/helper-replace-supers": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.25.0",
+				"@babel/traverse": "^7.25.0",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1228,6 +1188,23 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.0.tgz",
+			"integrity": "sha512-YLpb4LlYSc3sCUa35un84poXoraOiQucUTTu8X1j18JV+gNa8E0nyUf/CjZ171IRGr4jEguF+vzJU66QZhn29g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^7.25.0",
+				"@babel/helper-plugin-utils": "^7.24.8"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.7.tgz",
@@ -1297,15 +1274,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.7.tgz",
-			"integrity": "sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
+			"integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-compilation-targets": "^7.24.8",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/traverse": "^7.25.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1332,13 +1309,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.7.tgz",
-			"integrity": "sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
+			"integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1416,16 +1393,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.7.tgz",
-			"integrity": "sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.0.tgz",
+			"integrity": "sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-hoist-variables": "^7.24.7",
-				"@babel/helper-module-transforms": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7"
+				"@babel/helper-module-transforms": "^7.25.0",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1658,13 +1635,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-constant-elements": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
-			"integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.25.1.tgz",
+			"integrity": "sha512-SLV/giH/V4SmloZ6Dt40HjTGTAIkxn33TVIHxNGNvo8ezMhrxBkzisj4op1KZYPIOHFLqhv60OHvX+YRu4xbmQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1690,17 +1667,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
-			"integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+			"integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/plugin-syntax-jsx": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/types": "^7.25.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1888,15 +1865,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.8.tgz",
-			"integrity": "sha512-CgFgtN61BbdOGCP4fLaAMOPkzWUh6yQZNMr5YSt8uz2cZSSiQONCQFWqsE4NeVfOIhqDOlS9CR3WD91FzMeB2Q==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+			"integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-create-class-features-plugin": "^7.24.8",
+				"@babel/helper-create-class-features-plugin": "^7.25.0",
 				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
 				"@babel/plugin-syntax-typescript": "^7.24.7"
 			},
 			"engines": {
@@ -1974,20 +1952,21 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.8.tgz",
-			"integrity": "sha512-vObvMZB6hNWuDxhSaEPTKCwcqkAIuDtE+bQGn4XMXne1DSLzFVY8Vmj1bm+mUQXYNN8NmaQEO+r8MMbzPr1jBQ==",
+			"version": "7.25.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.3.tgz",
+			"integrity": "sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.24.8",
-				"@babel/helper-compilation-targets": "^7.24.8",
+				"@babel/compat-data": "^7.25.2",
+				"@babel/helper-compilation-targets": "^7.25.2",
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-validator-option": "^7.24.8",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.3",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.0",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.0",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.7",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.0",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -2008,29 +1987,30 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.24.7",
-				"@babel/plugin-transform-async-generator-functions": "^7.24.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.25.0",
 				"@babel/plugin-transform-async-to-generator": "^7.24.7",
 				"@babel/plugin-transform-block-scoped-functions": "^7.24.7",
-				"@babel/plugin-transform-block-scoping": "^7.24.7",
+				"@babel/plugin-transform-block-scoping": "^7.25.0",
 				"@babel/plugin-transform-class-properties": "^7.24.7",
 				"@babel/plugin-transform-class-static-block": "^7.24.7",
-				"@babel/plugin-transform-classes": "^7.24.8",
+				"@babel/plugin-transform-classes": "^7.25.0",
 				"@babel/plugin-transform-computed-properties": "^7.24.7",
 				"@babel/plugin-transform-destructuring": "^7.24.8",
 				"@babel/plugin-transform-dotall-regex": "^7.24.7",
 				"@babel/plugin-transform-duplicate-keys": "^7.24.7",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.0",
 				"@babel/plugin-transform-dynamic-import": "^7.24.7",
 				"@babel/plugin-transform-exponentiation-operator": "^7.24.7",
 				"@babel/plugin-transform-export-namespace-from": "^7.24.7",
 				"@babel/plugin-transform-for-of": "^7.24.7",
-				"@babel/plugin-transform-function-name": "^7.24.7",
+				"@babel/plugin-transform-function-name": "^7.25.1",
 				"@babel/plugin-transform-json-strings": "^7.24.7",
-				"@babel/plugin-transform-literals": "^7.24.7",
+				"@babel/plugin-transform-literals": "^7.25.2",
 				"@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
 				"@babel/plugin-transform-member-expression-literals": "^7.24.7",
 				"@babel/plugin-transform-modules-amd": "^7.24.7",
 				"@babel/plugin-transform-modules-commonjs": "^7.24.8",
-				"@babel/plugin-transform-modules-systemjs": "^7.24.7",
+				"@babel/plugin-transform-modules-systemjs": "^7.25.0",
 				"@babel/plugin-transform-modules-umd": "^7.24.7",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
 				"@babel/plugin-transform-new-target": "^7.24.7",
@@ -2143,9 +2123,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-			"integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+			"integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2156,35 +2136,32 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-			"integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/parser": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/parser": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
-			"integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+			"version": "7.25.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
+			"integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.8",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/helper-hoist-variables": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/parser": "^7.24.8",
-				"@babel/types": "^7.24.8",
+				"@babel/generator": "^7.25.0",
+				"@babel/parser": "^7.25.3",
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.2",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2193,9 +2170,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
-			"integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
+			"integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2215,9 +2192,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@csstools/cascade-layer-name-parser": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.13.tgz",
-			"integrity": "sha512-MX0yLTwtZzr82sQ0zOjqimpZbzjMaK/h2pmlrLK7DCzlmiZLYFpoO94WmN1akRVo6ll/TdpHb53vihHLUMyvng==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.0.tgz",
+			"integrity": "sha512-9GEQIvTMrjXfYaVnw1+FteDX5yF65CZq4ttYP75O3CANQevaCJ9jVVTiZt9YTpjYIk8C1mmf52y2S4Hr/CaE/g==",
 			"dev": true,
 			"funding": [
 				{
@@ -2231,11 +2208,11 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
@@ -2259,9 +2236,9 @@
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.2.4.tgz",
-			"integrity": "sha512-tfOuvUQeo7Hz+FcuOd3LfXVp+342pnWUJ7D2y8NUpu1Ww6xnTbHLpz018/y6rtbHifJ3iIEf9ttxXd8KG7nL0Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.0.0.tgz",
+			"integrity": "sha512-fxPxNrEVGeej4F35Xt69Q7gPMKa7oEGNxeP1DpA01sWpTF3Yhgux/0slVX3jLHd7dhlszeQlNAUhpAorVxoHdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2275,17 +2252,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-2.0.5.tgz",
-			"integrity": "sha512-lRZSmtl+DSjok3u9hTWpmkxFZnz7stkbZxzKc08aDUsdrWwhSgWo8yq9rq9DaFUtbAyAq2xnH92fj01S+pwIww==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.0.tgz",
+			"integrity": "sha512-F/A1Z3ZXH4fU6+29Up4QAZtewLmWLI4hVz6hyODMFvorx4AEC/03tu+gFq0nMZSDafC0lmapNOj9f4ctHMNaqQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2300,20 +2277,20 @@
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/color-helpers": "^4.2.1",
-				"@csstools/css-calc": "^1.2.4"
+				"@csstools/css-calc": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
-			"integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.0.tgz",
+			"integrity": "sha512-20hEErXV9GEx15qRbsJVzB91ryayx1F2duHPBrfZXQAHz/dJG0u/611URpr28+sFjm3EI7U17Pj9SVA9NSAGJA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2327,16 +2304,16 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-tokenizer": "^3.0.0"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.4.1.tgz",
-			"integrity": "sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.0.tgz",
+			"integrity": "sha512-efZvfJyYrqH9hPCKtOBywlTsCXnEzAI9sLHFzUsDpBb+1bQ+bxJnwL9V2bRKv9w4cpIp75yxGeZRaVKoMQnsEg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2350,13 +2327,13 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@csstools/media-query-list-parser": {
-			"version": "2.1.13",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz",
-			"integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.0.tgz",
+			"integrity": "sha512-W0JlkUFwXjo703wt06AcaWuUcS+6x6IEDyxV6W65Sw+vLCYp+uPsrps+PXTiIfN0V1Pqj5snPzN7EYLmbz1zjg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2370,17 +2347,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			}
 		},
 		"node_modules/@csstools/postcss-cascade-layers": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-4.0.6.tgz",
-			"integrity": "sha512-Xt00qGAQyqAODFiFEJNkTpSUz5VfYqnDLECdlA/Vv17nl/OIV5QfTRHGAXrBGG5YcJyHpJ+GF9gF/RZvOQz4oA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.0.tgz",
+			"integrity": "sha512-h+VunB3KXaoWTWEPBcdVk8Kz1eZ/CtDD+HXgKw5JLdbsViLEQdKUtFYH73VIQigdodng8s5DCrrwNQY7pnuWBA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2394,20 +2371,20 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/selector-specificity": "^3.1.1",
-				"postcss-selector-parser": "^6.0.13"
+				"@csstools/selector-specificity": "^4.0.0",
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-color-function": {
-			"version": "3.0.19",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-3.0.19.tgz",
-			"integrity": "sha512-d1OHEXyYGe21G3q88LezWWx31ImEDdmINNDy0LyLNN9ChgN2bPxoubUPiHf9KmwypBMaHmNcMuA/WZOKdZk/Lg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.0.tgz",
+			"integrity": "sha512-e0RohXUxMsSzIS5s4xh218NiOYXAfby17L8KYe/6ITI8i4BiSFLpywMvpA/d6xPUGUfT20O+7JLBDHF3heYZRA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2421,23 +2398,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-function": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-2.0.19.tgz",
-			"integrity": "sha512-mLvQlMX+keRYr16AuvuV8WYKUwF+D0DiCqlBdvhQ0KYEtcQl9/is9Ssg7RcIys8x0jIn2h1zstS4izckdZj9wg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.0.tgz",
+			"integrity": "sha512-MWuSfaLKe1By/hSnjH/Hj7ZOIRZaLMNshCTkVuuqtZ0nfp+QRGUwf9nb2uPVKySYjKqNERANdA9Q0citA9hK1Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2451,23 +2428,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-content-alt-text": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-1.0.0.tgz",
-			"integrity": "sha512-SkHdj7EMM/57GVvSxSELpUg7zb5eAndBeuvGwFzYtU06/QXJ/h9fuK7wO5suteJzGhm3GDF/EWPCdWV2h1IGHQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.0.tgz",
+			"integrity": "sha512-1pPjMaSUftwn/4N7RtJif91cB6BBEo0LQX2vryrDMF5uKDqt4RMpIi9ZFTsKtcXBFZexNGEWXZzPABnooJGkzQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2481,22 +2458,22 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-exponential-functions": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-1.0.9.tgz",
-			"integrity": "sha512-x1Avr15mMeuX7Z5RJUl7DmjhUtg+Amn5DZRD0fQ2TlTFTcJS8U1oxXQ9e5mA62S2RJgUU6db20CRoJyDvae2EQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-2.0.0.tgz",
+			"integrity": "sha512-sH7MBlsn6yft6xQ8uQ9MCWFHbZCUL3HIN3IntUabv75syl0dPldECTqLJix5q5ilSQxDQ1L+LajeZk84S6GG9w==",
 			"dev": true,
 			"funding": [
 				{
@@ -2510,21 +2487,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^1.2.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-calc": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-font-format-keywords": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-3.0.2.tgz",
-			"integrity": "sha512-E0xz2sjm4AMCkXLCFvI/lyl4XO6aN1NCSMMVEOngFDJ+k2rDwfr6NDjWljk1li42jiLNChVX+YFnmfGCigZKXw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-4.0.0.tgz",
+			"integrity": "sha512-usBzw9aCRDvchpok6C+4TXC57btc4bJtmKQWOHQxOVKen1ZfVqBUuCZ/wuqdX5GHsD0NRSr9XTP+5ID1ZZQBXw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2538,20 +2515,20 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-gamut-mapping": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-1.0.11.tgz",
-			"integrity": "sha512-KrHGsUPXRYxboXmJ9wiU/RzDM7y/5uIefLWKFSc36Pok7fxiPyvkSHO51kh+RLZS1W5hbqw9qaa6+tKpTSxa5g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.0.tgz",
+			"integrity": "sha512-JftxHVGt6PFfV/vWTDVKrrO0XyUA8OtuVykXhhMxue9qCzCCTSWqMHjZOvaOCCbxG1v2tGKV2FxBLQhzsZZPJg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2565,21 +2542,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-global-data": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-global-data/-/postcss-global-data-2.1.1.tgz",
-			"integrity": "sha512-tihdBLogY2G5jgUSu2jKSEVeOcnWqsz6k7UmPM7+ezhuV9FP5MIyX35Hc/YvqipQLRNsfBj9wRkBvsE7k1GM8A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-global-data/-/postcss-global-data-3.0.0.tgz",
+			"integrity": "sha512-3dR5+RDhPW1uqPWZUyTBSVn03gGbxzoSyCEpXugy9UMtXeyKjrB84dX3V8eggzooCsX8wcraKehzdouNO+MlsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2593,16 +2570,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-gradients-interpolation-method": {
-			"version": "4.0.20",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-4.0.20.tgz",
-			"integrity": "sha512-ZFl2JBHano6R20KB5ZrB8KdPM2pVK0u+/3cGQ2T8VubJq982I2LSOvQ4/VtxkAXjkPkk1rXt4AD1ni7UjTZ1Og==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.0.tgz",
+			"integrity": "sha512-jmgh7C6ANVRPdFNMNIp426UFNuy01XXYwxbbyYV2fZBbmZleVLp6imxjw2XoaeHMdSiYoq8vOeX+GVzCyC7oOQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2616,23 +2593,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-hwb-function": {
-			"version": "3.0.18",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-3.0.18.tgz",
-			"integrity": "sha512-3ifnLltR5C7zrJ+g18caxkvSRnu9jBBXCYgnBznRjxm6gQJGnnCO9H6toHfywNdNr/qkiVf2dymERPQLDnjLRQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.0.tgz",
+			"integrity": "sha512-Swb2CK/wKnsXEgT5GNlIO2C2h3lePn0Nmbsy48Z6yAht1XwQiDcxDAhqojg9LfonJVics+pzLM+IEQjPdgICNg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2646,23 +2623,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-ic-unit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-3.0.7.tgz",
-			"integrity": "sha512-YoaNHH2wNZD+c+rHV02l4xQuDpfR8MaL7hD45iJyr+USwvr0LOheeytJ6rq8FN6hXBmEeoJBeXXgGmM8fkhH4g==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.0.tgz",
+			"integrity": "sha512-9QT5TDGgx7wD3EEMN3BSUG6ckb6Eh5gSPT5kZoVtUuAonfPmLDJyPhqR4ntPpMYhUKAMVKAg3I/AgzqHMSeLhA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2676,21 +2653,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-initial": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-initial/-/postcss-initial-1.0.1.tgz",
-			"integrity": "sha512-wtb+IbUIrIf8CrN6MLQuFR7nlU5C7PwuebfeEXfjthUha1+XZj2RVi+5k/lukToA24sZkYAiSJfHM8uG/UZIdg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-initial/-/postcss-initial-2.0.0.tgz",
+			"integrity": "sha512-dv2lNUKR+JV+OOhZm9paWzYBXOCi+rJPqJ2cJuhh9xd8USVrd0cBEPczla81HNOyThMQWeCcdln3gZkQV2kYxA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2704,16 +2681,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-is-pseudo-class": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-4.0.8.tgz",
-			"integrity": "sha512-0aj591yGlq5Qac+plaWCbn5cpjs5Sh0daovYUKJUOMjIp70prGH/XPLp7QjxtbFXz3CTvb0H9a35dpEuIuUi3Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.0.tgz",
+			"integrity": "sha512-E/CjrT03BL06WmrjupnrT0VUBTvxJdoW1hRVeXFa9qatWtvcLLw0j8hP372G4A9PpSGEMXi3/AoHzPf7DNryCQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2727,20 +2704,20 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/selector-specificity": "^3.1.1",
-				"postcss-selector-parser": "^6.0.13"
+				"@csstools/selector-specificity": "^4.0.0",
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-light-dark-function": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-1.0.8.tgz",
-			"integrity": "sha512-x0UtpCyVnERsplUeoaY6nEtp1HxTf4lJjoK/ULEm40DraqFfUdUSt76yoOyX5rGY6eeOUOkurHyYlFHVKv/pew==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.0.tgz",
+			"integrity": "sha512-1CHfwwckSJ4xYZYOgJD5u1NNlP85/6VqsQPL1geagvfpwm47hcGRDW+O3CD7KdexWGL45E5qKmL1bC2siqjmkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2754,22 +2731,22 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-logical-float-and-clear": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-2.0.1.tgz",
-			"integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-3.0.0.tgz",
+			"integrity": "sha512-SEmaHMszwakI2rqKRJgE+8rpotFfne1ZS6bZqBoQIicFyV+xT1UF42eORPxJkVJVrH9C0ctUgwMSn3BLOIZldQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2783,16 +2760,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-logical-overflow": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overflow/-/postcss-logical-overflow-1.0.1.tgz",
-			"integrity": "sha512-Kl4lAbMg0iyztEzDhZuQw8Sj9r2uqFDcU1IPl+AAt2nue8K/f1i7ElvKtXkjhIAmKiy5h2EY8Gt/Cqg0pYFDCw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overflow/-/postcss-logical-overflow-2.0.0.tgz",
+			"integrity": "sha512-spzR1MInxPuXKEX2csMamshR4LRaSZ3UXVaRGjeQxl70ySxOhMpP2252RAFsg8QyyBXBzuVOOdx1+bVO5bPIzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2806,16 +2783,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-logical-overscroll-behavior": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overscroll-behavior/-/postcss-logical-overscroll-behavior-1.0.1.tgz",
-			"integrity": "sha512-+kHamNxAnX8ojPCtV8WPcUP3XcqMFBSDuBuvT6MHgq7oX4IQxLIXKx64t7g9LiuJzE7vd06Q9qUYR6bh4YnGpQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overscroll-behavior/-/postcss-logical-overscroll-behavior-2.0.0.tgz",
+			"integrity": "sha512-e/webMjoGOSYfqLunyzByZj5KKe5oyVg/YSbie99VEaSDE2kimFm0q1f6t/6Jo+VVCQ/jbe2Xy+uX+C4xzWs4w==",
 			"dev": true,
 			"funding": [
 				{
@@ -2829,16 +2806,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-logical-resize": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-resize/-/postcss-logical-resize-2.0.1.tgz",
-			"integrity": "sha512-W5Gtwz7oIuFcKa5SmBjQ2uxr8ZoL7M2bkoIf0T1WeNqljMkBrfw1DDA8/J83k57NQ1kcweJEjkJ04pUkmyee3A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-resize/-/postcss-logical-resize-3.0.0.tgz",
+			"integrity": "sha512-DFbHQOFW/+I+MY4Ycd/QN6Dg4Hcbb50elIJCfnwkRTCX05G11SwViI5BbBlg9iHRl4ytB7pmY5ieAFk3ws7yyg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2855,16 +2832,16 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-logical-viewport-units": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-viewport-units/-/postcss-logical-viewport-units-2.0.11.tgz",
-			"integrity": "sha512-ElITMOGcjQtvouxjd90WmJRIw1J7KMP+M+O87HaVtlgOOlDt1uEPeTeii8qKGe2AiedEp0XOGIo9lidbiU2Ogg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-logical-viewport-units/-/postcss-logical-viewport-units-3.0.0.tgz",
+			"integrity": "sha512-7a0d7TLfHP3k7n+XGj5NJopgyKgl/VKyAPapYIo97aujB7+8M4dBE1Og0OmWng+H/drQWXoSlCI3pov5XwVtxQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2878,20 +2855,20 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-media-minmax": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-1.1.8.tgz",
-			"integrity": "sha512-KYQCal2i7XPNtHAUxCECdrC7tuxIWQCW+s8eMYs5r5PaAiVTeKwlrkRS096PFgojdNCmHeG0Cb7njtuNswNf+w==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-2.0.0.tgz",
+			"integrity": "sha512-21Cmy5QWbexbpKAAJntGomjn644BWWs7gXkx/Vid1SjqxIRmPUB/dcJ4xBWwjpFuhrPKzT8a3Pr+IJv9R9v9Yg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2905,22 +2882,22 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^1.2.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/media-query-list-parser": "^2.1.13"
+				"@csstools/css-calc": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/media-query-list-parser": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-queries-aspect-ratio-number-values/-/postcss-media-queries-aspect-ratio-number-values-2.0.11.tgz",
-			"integrity": "sha512-YD6jrib20GRGQcnOu49VJjoAnQ/4249liuz7vTpy/JfgqQ1Dlc5eD4HPUMNLOw9CWey9E6Etxwf/xc/ZF8fECA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-queries-aspect-ratio-number-values/-/postcss-media-queries-aspect-ratio-number-values-3.0.0.tgz",
+			"integrity": "sha512-TV8Q7ec0zbCxlmTmUF8CvAWWbK3q9ops3+sGCc6rHAGrfkoA+HyMGwJBZudddZQOV9MZS949mhtYIV4AgIRizw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2934,21 +2911,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/media-query-list-parser": "^2.1.13"
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/media-query-list-parser": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-nested-calc": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-3.0.2.tgz",
-			"integrity": "sha512-ySUmPyawiHSmBW/VI44+IObcKH0v88LqFe0d09Sb3w4B1qjkaROc6d5IA3ll9kjD46IIX/dbO5bwFN/swyoyZA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-4.0.0.tgz",
+			"integrity": "sha512-jMYDdqrQQxE7k9+KjstC3NbsmC063n1FTPLCgCRS2/qHUbHM0mNy9pIn4QIiQGs9I/Bg98vMqw7mJXBxa0N88A==",
 			"dev": true,
 			"funding": [
 				{
@@ -2962,20 +2939,20 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-normalize-display-values": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-3.0.2.tgz",
-			"integrity": "sha512-fCapyyT/dUdyPtrelQSIV+d5HqtTgnNP/BEG9IuhgXHt93Wc4CfC1bQ55GzKAjWrZbgakMQ7MLfCXEf3rlZJOw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.0.tgz",
+			"integrity": "sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2992,16 +2969,16 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-oklab-function": {
-			"version": "3.0.19",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-3.0.19.tgz",
-			"integrity": "sha512-e3JxXmxjU3jpU7TzZrsNqSX4OHByRC3XjItV3Ieo/JEQmLg5rdOL4lkv/1vp27gXemzfNt44F42k/pn0FpE21Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.0.tgz",
+			"integrity": "sha512-4dwot1KLiFRFbYZV2XeeNoXQETK/3MaNCi4BpDlJ5J4XHF+VRwcppfCcqCC+TRucWanPFFlbt+X53nIuK7JVNg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3015,23 +2992,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-progressive-custom-properties": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-3.3.0.tgz",
-			"integrity": "sha512-W2oV01phnILaRGYPmGFlL2MT/OgYjQDrL9sFlbdikMFi6oQkFki9B86XqEWR7HCsTZFVq7dbzr/o71B75TKkGg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.0.0.tgz",
+			"integrity": "sha512-XQPtROaQjomnvLUSy/bALTR5VCtTVUFwYs1SblvYgLSeTo2a/bMNwUwo2piXw5rTv/FEYiy5yPSXBqg9OKUx7Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3048,16 +3025,16 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-relative-color-syntax": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-2.0.19.tgz",
-			"integrity": "sha512-MxUMSNvio1WwuS6WRLlQuv6nNPXwIWUFzBBAvL/tBdWfiKjiJnAa6eSSN5gtaacSqUkQ/Ce5Z1OzLRfeaWhADA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.0.tgz",
+			"integrity": "sha512-iE/mgtuUeFMpMJhhrze9pu5xSEaueCTijs7lTnJ6MoTL50H9fquQp3bFVd2haAb/fDhO/nXTu67tzsm+zXsFzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3071,23 +3048,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-scope-pseudo-class": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-scope-pseudo-class/-/postcss-scope-pseudo-class-3.0.1.tgz",
-			"integrity": "sha512-3ZFonK2gfgqg29gUJ2w7xVw2wFJ1eNWVDONjbzGkm73gJHVCYK5fnCqlLr+N+KbEfv2XbWAO0AaOJCFB6Fer6A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-scope-pseudo-class/-/postcss-scope-pseudo-class-4.0.0.tgz",
+			"integrity": "sha512-+ZUOBtVMDcmHZcZqsP/jcNRriEILfWQflTI3tCTA+/RheXAg57VkFGyPDAilpQSqlCpxWLWG8VUFKFtZJPwuOg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3101,19 +3078,19 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-stepped-value-functions": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-3.0.10.tgz",
-			"integrity": "sha512-MZwo0D0TYrQhT5FQzMqfy/nGZ28D1iFtpN7Su1ck5BPHS95+/Y5O9S4kEvo76f2YOsqwYcT8ZGehSI1TnzuX2g==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-4.0.0.tgz",
+			"integrity": "sha512-sJUW1axQuxRyD59zr9hMJ6MoM/99UkxNc7fxJ1kFdTl1B5dS3TxvVzY1fRq1C/JsgBw6uNzfy/i52SrVNtbbXw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3127,21 +3104,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^1.2.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-calc": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-text-decoration-shorthand": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-3.0.7.tgz",
-			"integrity": "sha512-+cptcsM5r45jntU6VjotnkC9GteFR7BQBfZ5oW7inLCxj7AfLGAzMbZ60hKTP13AULVZBdxky0P8um0IBfLHVA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.0.tgz",
+			"integrity": "sha512-vyJpbr2emWy8AOmBT+41LcAaaS8Q3jOMiMZRzrdV8uZgKI1I0NiB+UM7vJuwkFPhC3oXl7XPIPtajsyEAvI3kw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3159,16 +3136,16 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-trigonometric-functions": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-3.0.10.tgz",
-			"integrity": "sha512-G9G8moTc2wiad61nY5HfvxLiM/myX0aYK4s1x8MQlPH29WDPxHQM7ghGgvv2qf2xH+rrXhztOmjGHJj4jsEqXw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-4.0.0.tgz",
+			"integrity": "sha512-M7CivX++ZOQvnF+eZ8FHg2X8GYOfSUFH6GRtr7mGeIgd38WmT1WCBogqBvz/Y5x9VUeor9EuJX2K06bP7p4BuA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3182,21 +3159,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^1.2.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1"
+				"@csstools/css-calc": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/postcss-unset-value": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-3.0.1.tgz",
-			"integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-4.0.0.tgz",
+			"integrity": "sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3210,16 +3187,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/@csstools/selector-resolve-nested": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
-			"integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-2.0.0.tgz",
+			"integrity": "sha512-oklSrRvOxNeeOW1yARd4WNCs/D09cQjunGZUgSq6vM8GpzFswN+8rBZyJA29YFZhOTQ6GFzxgLDNtVbt9wPZMA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3233,16 +3210,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-			"integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
+			"integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3256,16 +3233,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			}
 		},
 		"node_modules/@csstools/utilities": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-1.0.0.tgz",
-			"integrity": "sha512-tAgvZQe/t2mlvpNosA4+CkMiZ2azISW5WPAcdSalZlEjQvUfghHxfQcrCiK/7/CrfAWVxyM88kGFYO82heIGDg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-2.0.0.tgz",
+			"integrity": "sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3279,7 +3256,7 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -4014,14 +3991,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-			"integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
+			"integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.45.3"
+				"playwright": "1.46.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4847,9 +4824,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/http-proxy": {
-			"version": "1.17.14",
-			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-			"integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+			"version": "1.17.15",
+			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+			"integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4931,13 +4908,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-			"integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
+			"integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.13.0"
 			}
 		},
 		"node_modules/@types/node-forge": {
@@ -5084,9 +5061,9 @@
 			}
 		},
 		"node_modules/@types/webpack": {
-			"version": "4.41.38",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
-			"integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
+			"version": "4.41.39",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.39.tgz",
+			"integrity": "sha512-otxUJvoi6FbBq/64gGH34eblpKLgdi+gf08GaAh8Bx6So0ZZic028Ev/SUxD22gbthMKCkeeiXEat1kHLDJfYg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5121,9 +5098,9 @@
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.11",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.11.tgz",
-			"integrity": "sha512-4+q7P5h3SpJxaBft0Dzpbr6lmMaqh0Jr2tbhJZ/luAwvD7ohSCniYkwz/pLxuT2h0EOa6QADgJj1Ko+TzRfZ+w==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5131,9 +5108,9 @@
 			}
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"version": "17.0.33",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+			"integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5585,9 +5562,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.4.0.tgz",
-			"integrity": "sha512-BIbHlZxXGG6gEDrTUJ3s7wU2mAPbHFCkc7QkeTD+7GMIixEzEPr7IBbrpHkcwLIRWqEvc9LB69YPrWklUKJZmg==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.5.0.tgz",
+			"integrity": "sha512-ra9UWhidrAIoYTuqIIMFs+5LawUis/qDhiB2c3mc9HJUXXQDOvdhww5f9H9SjWqOo1oB9jSuVh4pXtBpcR1E6A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5597,8 +5574,8 @@
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-typescript": "^7.16.0",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/browserslist-config": "^6.4.0",
-				"@wordpress/warning": "^3.4.0",
+				"@wordpress/browserslist-config": "^6.5.0",
+				"@wordpress/warning": "^3.5.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -5609,9 +5586,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.4.0.tgz",
-			"integrity": "sha512-W/Tazd2nhiMoUWtZD0rVRbByH2uXakOR6htnqM1NT2dbnwWS/NsT0AQVY5JMTIrGQ8p4BSgq68/+xb1r4DXxTw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.5.0.tgz",
+			"integrity": "sha512-7sXNXkF/oayvnupDLMfDktkvDlCt8V9jOgKFWhWeVrthwccI8hYLylS7ZHsD1+Cg2uKfQ1In4xJ4ThHNjl2JUQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5620,9 +5597,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.4.0.tgz",
-			"integrity": "sha512-6Uvh++K+UCOSSlE589uHtxVWa7vJmcFjDYHT7/VsdrHkwpCRwJd0UAUrmTBqiekGYo3NQzZW/ikODxR+lkORjw==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.5.0.tgz",
+			"integrity": "sha512-B5cYN5INRknBjzbNH2qJOq6x66qXS2UoLk5Ebyew1JkW9xzvX1O+eQumjFv65fAN6RNPtomHs8c7BNoD3wAebQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5631,13 +5608,13 @@
 			}
 		},
 		"node_modules/@wordpress/create-block": {
-			"version": "4.47.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.47.0.tgz",
-			"integrity": "sha512-jAB3FBw6gHf5Ll+Fj419nIbrQl/+Hx6N5dP+Qzjw4NUgH6LmTn9zqv9Azit2lv/iJ3XSuNJQ6Fkvg2tUkagPGg==",
+			"version": "4.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.48.0.tgz",
+			"integrity": "sha512-Gt5i4Qhc0XE4XDcM/eQv0UIt7+Neu02mv+sL9IrxDRJSaYg1CWPodYkuqmSCsHkcwXYzpDr/z0PHnALVUE66rQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/lazy-import": "^2.4.0",
+				"@wordpress/lazy-import": "^2.5.0",
 				"chalk": "^4.0.0",
 				"change-case": "^4.1.2",
 				"check-node-version": "^4.1.0",
@@ -5660,9 +5637,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.4.0.tgz",
-			"integrity": "sha512-9CmC+8SSQ4Oh/IghVg8YQjBIKpvuxn18m+Painq6SdJGseJhRgnFINVUwHCs1BRR1sB4BUTldnUlNiya43EK1w==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.5.0.tgz",
+			"integrity": "sha512-UpbBNUh+lc8cquul08c6jKVgjxf6+pUJE3Rd08kDz3DUrD3sq3W8lYnJ92mqcZO1RgoZGwtM6Swbliv6erxV8g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5677,9 +5654,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.4.0.tgz",
-			"integrity": "sha512-kp88FLUU1SJAtxlRF5jNWYYmOSmpVrVLXuLTZmmXDMp/FFd0vzNDKwZ7TV6fd0B58cxyUydaG6e+hxLMeSYQtw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.5.0.tgz",
+			"integrity": "sha512-gQuhdDMejum7a4hWW4ejIWSBv1xeeCFda5o7eq766evarU+HwcN+4GPiSYKj2iEHJ4dge1On2VXeg1RFLY3w5Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5699,17 +5676,17 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "20.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-20.1.0.tgz",
-			"integrity": "sha512-2FVQsdvG92qiKKnXhR0JO4RVyjrdRVY5vS6C6OZjp4M+O/kC/k5sx/BsjOX09qyUGletXJyQRmy11uoCE9lmAA==",
+			"version": "20.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-20.2.0.tgz",
+			"integrity": "sha512-lC8sUkzf4x3ByQHs3xF7X0XxS3SPEYzXho9+NeIgB5Cg0s/PlyWuPQI+4oHVgZI3hzPH76G6ewRtIt27gQRcdw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.4.0",
-				"@wordpress/prettier-config": "^4.4.0",
+				"@wordpress/babel-preset-default": "^8.5.0",
+				"@wordpress/prettier-config": "^4.5.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
@@ -5789,9 +5766,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.4.0.tgz",
-			"integrity": "sha512-vwfpSmCWpOx2IyCfjNJu8Ior4JK4D43T5YhPF6UpjHE+T+h3t3SwqriKYFbExDz+cdYwjJt4mpUEk8vh3lcfdQ==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.5.0.tgz",
+			"integrity": "sha512-kcNNbPFUNMCZfeNgPoee2SpyL3XgNTuPdKHa3JBM/lUNiWl1FAxFnqmElM/0UBUrVdbl/NmggVdOspsCE0eY8w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5807,13 +5784,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.4.0.tgz",
-			"integrity": "sha512-HJNzQEW2bdznObUcU3lbkPAYaNZlZkrP3+ye+GG/m/iy6xg2n9rvOqI1s2JieiWLCbCAiLLBm1zqTWtuEaf0BQ==",
+			"version": "12.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.5.0.tgz",
+			"integrity": "sha512-VeSW5dbZzwrNF0ffpZedTLbj1wG7ByJflReMRwT/ljjIK+CDTUCUbLynnGsvSfV/lc2GzNqI6bqgY22DmK53Lw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.4.0",
+				"@wordpress/jest-console": "^8.5.0",
 				"babel-jest": "^29.6.2"
 			},
 			"engines": {
@@ -5826,9 +5803,9 @@
 			}
 		},
 		"node_modules/@wordpress/lazy-import": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-2.4.0.tgz",
-			"integrity": "sha512-UKOUaymvjyD6YTE+lDs6yqHpcDZIuYgn6NMwnpoXz4gifWw/tmMVQKtaqUArW7sBsJrGhcFMAX8uMyUYpWIroQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-2.5.0.tgz",
+			"integrity": "sha512-9o6nybyYwhw4Vc80Ig4x2pgFjiP03V3TY3jB2EOVxXeTX5ObTPVoPwsuy8e/2lK+dIGIKbgfj1r4RoeKlt+pLA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5842,9 +5819,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.4.0.tgz",
-			"integrity": "sha512-5ADmUubsY9HK9qat87DpjMIEiGfVIL2xbmZiOyzQ9fiLDFLg9i9snhjbxqEnTqc/WilRg0Fd66k+E6yHV7YDoA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.5.0.tgz",
+			"integrity": "sha512-W48a+iIwia+RXN6fg6vxUZj4fyrbuRKFiEV0sIOsxKRJK9zFSink/RKEEKq3aLT17QUTcQjuV2DA4f+eSVaadA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5856,13 +5833,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.4.0.tgz",
-			"integrity": "sha512-nfH9yw1Xbzqf6/kKKXVl1gmuyqVs9vBoAuqyrVYMt2wxk6/G7EEHNqI141SVZ2+O7wlMc9UNZMAEcApTmQ9N8g==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.5.0.tgz",
+			"integrity": "sha512-DatUnlrFMX6MtW+KsmuMiLaBSad78oX5nsroZPSFveXELL6CD5BHNcc24SoV2U8XI5ZGNJHHxzqVar/TQ2tbSQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^5.4.0",
+				"@wordpress/base-styles": "^5.5.0",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -5874,9 +5851,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.4.0.tgz",
-			"integrity": "sha512-etguLCGd8r0solW9pkUeBHGuqrsCGL+d2JzCB3APhDo3mYD+TK2PUg3EfXKOvJzHsQwHg73h0eW9/C5DU+ll+Q==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.5.0.tgz",
+			"integrity": "sha512-HxpR4128yfJJs1idQaBJfBffa6P2JXKN7mvx+D/G2UukjjWlXHaCXLO8wuBLnXwXSg4pOq5vfDM/p5TawZd7Zg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5888,25 +5865,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "28.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-28.4.0.tgz",
-			"integrity": "sha512-z15ytMLQZdQRbpaUFkkhAmGFVzD/bBCClQ/1HOINbJu1j8y+WGTuP0HFn45I/+B+ynOKBQjisOCf8ZI3s290/g==",
+			"version": "28.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-28.5.0.tgz",
+			"integrity": "sha512-J98tOf5+nWaKneVpGqCB8RcBzm/Rv+SWVIgTvUE3AOtp721r7GBkClLMDzjwC08sYW2cANG/JCYZ69LHaK3mlg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.4.0",
-				"@wordpress/browserslist-config": "^6.4.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.4.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.4.0",
-				"@wordpress/eslint-plugin": "^20.1.0",
-				"@wordpress/jest-preset-default": "^12.4.0",
-				"@wordpress/npm-package-json-lint-config": "^5.4.0",
-				"@wordpress/postcss-plugins-preset": "^5.4.0",
-				"@wordpress/prettier-config": "^4.4.0",
-				"@wordpress/stylelint-config": "^22.4.0",
+				"@wordpress/babel-preset-default": "^8.5.0",
+				"@wordpress/browserslist-config": "^6.5.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.5.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.5.0",
+				"@wordpress/eslint-plugin": "^20.2.0",
+				"@wordpress/jest-preset-default": "^12.5.0",
+				"@wordpress/npm-package-json-lint-config": "^5.5.0",
+				"@wordpress/postcss-plugins-preset": "^5.5.0",
+				"@wordpress/prettier-config": "^4.5.0",
+				"@wordpress/stylelint-config": "^22.5.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "^29.6.2",
 				"babel-loader": "^8.2.3",
@@ -6498,9 +6475,9 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-22.4.0.tgz",
-			"integrity": "sha512-oi1+yLqyDU7zP1qLHm2iPihltSelSFzNb8UBvRdExsUROZF+xHxBBz5R1El+KSTTSBguRfvUMufJAMQTDAS7dA==",
+			"version": "22.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-22.5.0.tgz",
+			"integrity": "sha512-CgKU37JVYgcje8SUXt87/5tWpor6zYm+mFf4FGZFPDCIGh9KXuLfsfyau4sJ2YI16qMlFiSwyWQMKWG86p1AhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6516,9 +6493,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.4.0.tgz",
-			"integrity": "sha512-0LbBvyRLZVulwVcseH+WryDlnP//CFBwAq15+XzzoZc3s0ANlGsLPTlYamZ7eoyosGQZVKqG/yzP3DAlESj89w==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
+			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6620,9 +6597,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.14",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
-			"integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.15.tgz",
+			"integrity": "sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7120,9 +7097,9 @@
 			"license": "MIT"
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.19",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-			"integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+			"version": "10.4.20",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
 			"dev": true,
 			"funding": [
 				{
@@ -7140,11 +7117,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.0",
-				"caniuse-lite": "^1.0.30001599",
+				"browserslist": "^4.23.3",
+				"caniuse-lite": "^1.0.30001646",
 				"fraction.js": "^4.3.7",
 				"normalize-range": "^0.1.2",
-				"picocolors": "^1.0.0",
+				"picocolors": "^1.0.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"bin": {
@@ -7174,9 +7151,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
-			"integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+			"integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -7184,9 +7161,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-			"integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+			"integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7332,14 +7309,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
-			"integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.1",
-				"core-js-compat": "^3.36.1"
+				"@babel/helper-define-polyfill-provider": "^0.6.2",
+				"core-js-compat": "^3.38.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -7720,9 +7697,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-			"integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+			"version": "4.23.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
 			"dev": true,
 			"funding": [
 				{
@@ -7740,9 +7717,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001640",
-				"electron-to-chromium": "^1.4.820",
-				"node-releases": "^2.0.14",
+				"caniuse-lite": "^1.0.30001646",
+				"electron-to-chromium": "^1.5.4",
+				"node-releases": "^2.0.18",
 				"update-browserslist-db": "^1.1.0"
 			},
 			"bin": {
@@ -7947,9 +7924,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001643",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
-			"integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
+			"version": "1.0.30001651",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+			"integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
 			"dev": true,
 			"funding": [
 				{
@@ -8619,9 +8596,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-			"integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
+			"integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8631,13 +8608,13 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
-			"integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
+			"integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.0"
+				"browserslist": "^4.23.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -8645,9 +8622,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.37.1.tgz",
-			"integrity": "sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.0.tgz",
+			"integrity": "sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8804,9 +8781,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/css-blank-pseudo": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-6.0.2.tgz",
-			"integrity": "sha512-J/6m+lsqpKPqWHOifAFtKFeGLOzw3jR92rxQcwRUfA/eTuZzKfKlxOmYDx2+tqOPQAueNvBiY8WhAeHu5qNmTg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-7.0.0.tgz",
+			"integrity": "sha512-v9xXYGdm6LIn4iHEfu3egk/PM1g/yJr8uwTIj6E44kurv5dE/4y3QW7WdVmZ0PVnqfTuK+C0ClZcEEiaKWBL9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -8820,10 +8797,10 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8853,9 +8830,9 @@
 			}
 		},
 		"node_modules/css-has-pseudo": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-6.0.5.tgz",
-			"integrity": "sha512-ZTv6RlvJJZKp32jPYnAJVhowDCrRrHUTAxsYSuUPBEDJjzws6neMnzkRblxtgmv1RgcV5dhH2gn7E3wA9Wt6lw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.0.tgz",
+			"integrity": "sha512-vO6k9bBt4/eEZ2PeHmS2VXjJga5SBy6O1ESyaOkse5/lvp6piFqg8Sh5KTU7X33M7Uh/oqo+M3EeMktQrZoTCQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8869,12 +8846,12 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/selector-specificity": "^3.1.1",
-				"postcss-selector-parser": "^6.0.13",
+				"@csstools/selector-specificity": "^4.0.0",
+				"postcss-selector-parser": "^6.1.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8917,9 +8894,9 @@
 			}
 		},
 		"node_modules/css-prefers-color-scheme": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-9.0.1.tgz",
-			"integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-10.0.0.tgz",
+			"integrity": "sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8933,7 +8910,7 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -9014,13 +8991,13 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.4.tgz",
-			"integrity": "sha512-rQgpZra72iFjiheNreXn77q1haS2GEy69zCMbu4cpXCFPMQF+D4Ik5V7ktMzUF/sA7xCIgcqHwGPnCD+0a1vHg==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.5.tgz",
+			"integrity": "sha512-Aq0vqBLtpTT5Yxj+hLlLfNPFuRQCDIjx5JQAhhaedQKLNDvDGeVziF24PS+S1f0Z5KCxWvw0QVI3VNHNBITxVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cssnano-preset-default": "^7.0.4",
+				"cssnano-preset-default": "^7.0.5",
 				"lilconfig": "^3.1.2"
 			},
 			"engines": {
@@ -9035,42 +9012,42 @@
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.4.tgz",
-			"integrity": "sha512-jQ6zY9GAomQX7/YNLibMEsRZguqMUGuupXcEk2zZ+p3GUxwCAsobqPYE62VrJ9qZ0l9ltrv2rgjwZPBIFIjYtw==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.5.tgz",
+			"integrity": "sha512-Jbzja0xaKwc5JzxPQoc+fotKpYtWEu4wQLMQe29CM0FjjdRjA4omvbGHl2DTGgARKxSTpPssBsok+ixv8uTBqw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"css-declaration-sorter": "^7.2.0",
 				"cssnano-utils": "^5.0.0",
-				"postcss-calc": "^10.0.0",
-				"postcss-colormin": "^7.0.1",
-				"postcss-convert-values": "^7.0.2",
-				"postcss-discard-comments": "^7.0.1",
-				"postcss-discard-duplicates": "^7.0.0",
+				"postcss-calc": "^10.0.1",
+				"postcss-colormin": "^7.0.2",
+				"postcss-convert-values": "^7.0.3",
+				"postcss-discard-comments": "^7.0.2",
+				"postcss-discard-duplicates": "^7.0.1",
 				"postcss-discard-empty": "^7.0.0",
 				"postcss-discard-overridden": "^7.0.0",
-				"postcss-merge-longhand": "^7.0.2",
-				"postcss-merge-rules": "^7.0.2",
+				"postcss-merge-longhand": "^7.0.3",
+				"postcss-merge-rules": "^7.0.3",
 				"postcss-minify-font-values": "^7.0.0",
 				"postcss-minify-gradients": "^7.0.0",
-				"postcss-minify-params": "^7.0.1",
-				"postcss-minify-selectors": "^7.0.2",
+				"postcss-minify-params": "^7.0.2",
+				"postcss-minify-selectors": "^7.0.3",
 				"postcss-normalize-charset": "^7.0.0",
 				"postcss-normalize-display-values": "^7.0.0",
 				"postcss-normalize-positions": "^7.0.0",
 				"postcss-normalize-repeat-style": "^7.0.0",
 				"postcss-normalize-string": "^7.0.0",
 				"postcss-normalize-timing-functions": "^7.0.0",
-				"postcss-normalize-unicode": "^7.0.1",
+				"postcss-normalize-unicode": "^7.0.2",
 				"postcss-normalize-url": "^7.0.0",
 				"postcss-normalize-whitespace": "^7.0.0",
 				"postcss-ordered-values": "^7.0.1",
-				"postcss-reduce-initial": "^7.0.1",
+				"postcss-reduce-initial": "^7.0.2",
 				"postcss-reduce-transforms": "^7.0.0",
 				"postcss-svgo": "^7.0.1",
-				"postcss-unique-selectors": "^7.0.1"
+				"postcss-unique-selectors": "^7.0.2"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -9263,9 +9240,9 @@
 			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9905,9 +9882,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.1.tgz",
-			"integrity": "sha512-FKbOCOQ5QRB3VlIbl1LZQefWIYwszlBloaXcY2rbfpu9ioJnNh3TK03YtIDKDo3WKBi8u+YV4+Fn2CkEozgf4w==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
+			"integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -15101,9 +15078,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz",
-			"integrity": "sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.1.tgz",
+			"integrity": "sha512-elBx2l/tp9z99X5H/qev8uyDywVh0VXAwEbjk8kJhnc5grOFkGh7aW6q55me9xnYbss261XtnUrysZ+XvGbhQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15122,9 +15099,9 @@
 			}
 		},
 		"node_modules/lefthook": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.7.7.tgz",
-			"integrity": "sha512-b1giMxEuEb4MBcSkrEpQSFs5W9+vPlahAltxhWCqqarNzz8oisD4bMA/UGYAn/lvUhhC6oFo98zetQNpvjXp5Q==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.7.12.tgz",
+			"integrity": "sha512-kZQQAeL4JZbsADqzK5YMP7M0aadGVDha7oo+4exA5FeQbgpmnDq+ejbkdfLOdo9uy7FSY82akmbxAiXq+V4fbg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -15132,20 +15109,20 @@
 				"lefthook": "bin/index.js"
 			},
 			"optionalDependencies": {
-				"lefthook-darwin-arm64": "1.7.7",
-				"lefthook-darwin-x64": "1.7.7",
-				"lefthook-freebsd-arm64": "1.7.7",
-				"lefthook-freebsd-x64": "1.7.7",
-				"lefthook-linux-arm64": "1.7.7",
-				"lefthook-linux-x64": "1.7.7",
-				"lefthook-windows-arm64": "1.7.7",
-				"lefthook-windows-x64": "1.7.7"
+				"lefthook-darwin-arm64": "1.7.12",
+				"lefthook-darwin-x64": "1.7.12",
+				"lefthook-freebsd-arm64": "1.7.12",
+				"lefthook-freebsd-x64": "1.7.12",
+				"lefthook-linux-arm64": "1.7.12",
+				"lefthook-linux-x64": "1.7.12",
+				"lefthook-windows-arm64": "1.7.12",
+				"lefthook-windows-x64": "1.7.12"
 			}
 		},
 		"node_modules/lefthook-darwin-arm64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.7.7.tgz",
-			"integrity": "sha512-EtINYW/1jJDMSlBbCwiZhHRMwybJkuawg9/dtHMll9gE63yBTOQSoqLzjOJWioHKK9DrgAfe2Mh5+PSt0cLVRA==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.7.12.tgz",
+			"integrity": "sha512-CjbV968FMFJWBe/5UA4H3DiKH5TFCh0449pfr9NTt14r05FIg6YzLf5h97CYlDz3b0Bx8Iz8ZqoguE1dFrYpsg==",
 			"cpu": [
 				"arm64"
 			],
@@ -15157,9 +15134,9 @@
 			]
 		},
 		"node_modules/lefthook-darwin-x64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.7.7.tgz",
-			"integrity": "sha512-77fHVtvLeInztn88fZOsiNMlP5Ql6eG8D233k1G1zndRxwCnVVlB6GVLC/0SRmdE9cR7U66CSphN6EClZrvyHQ==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.7.12.tgz",
+			"integrity": "sha512-EEwh5zU65MwfwkGOpBW7rd0Ldg7Ef17VoFUQ/pr408acLq7BvNOrrFga/RNUvB5Hsaa7eNjBbv0AG02qE3X/ZA==",
 			"cpu": [
 				"x64"
 			],
@@ -15171,9 +15148,9 @@
 			]
 		},
 		"node_modules/lefthook-freebsd-arm64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.7.7.tgz",
-			"integrity": "sha512-y2+T2ONfr9DYxyx1JGItBf1ARGx0RJcAOn9pEfSN1LrEOAvcVlQKDE8+evdmt8uhMo5TVi+gFe1tdtsIbsiQTA==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.7.12.tgz",
+			"integrity": "sha512-BznKfuFw9lWhqJFrI+ci2EyS5vvfEWTcsISTq0o4a/kR058stK/6B+i+XnTHrHsiOjQbLJ42wcFgvUEFmio6yw==",
 			"cpu": [
 				"arm64"
 			],
@@ -15185,9 +15162,9 @@
 			]
 		},
 		"node_modules/lefthook-freebsd-x64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.7.7.tgz",
-			"integrity": "sha512-6zbprxvq7bBG7ihSA1R/GCC5iN+q9tbjQXKiOI+d63F/Oo5ld/kF5fIZv50K39ujx1Ykdmg5llEIBeDEHuybZQ==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.7.12.tgz",
+			"integrity": "sha512-9+I0xakvqpAIxhPb5ON6a5v/Iyl+gahJi+ogoEDNqlg3zj4otZspOvdiAsLWBAaXI+yFQftOHBM8940Ki5RB0A==",
 			"cpu": [
 				"x64"
 			],
@@ -15199,9 +15176,9 @@
 			]
 		},
 		"node_modules/lefthook-linux-arm64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.7.7.tgz",
-			"integrity": "sha512-bUpDortnX1ACCd38uv2+I9vdsyP9Oe9FXZ4E/xX8nl+hnkgC80/nv1KxRI7MlaDdb1z4VgEO/0pT2OU1nM1C/A==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.7.12.tgz",
+			"integrity": "sha512-FC+4cyz2CUBVL4BnDwnAzQPdBHM80O2TM53qoT1R3sn9LbWwcpnwdXi86NhVD0I7+vKg6rGUKgOQMTZfSe+sDg==",
 			"cpu": [
 				"arm64"
 			],
@@ -15213,9 +15190,9 @@
 			]
 		},
 		"node_modules/lefthook-linux-x64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.7.7.tgz",
-			"integrity": "sha512-8dEuO0AzQkWFKSRvd2rzb/LtmgtEoQHhzgTANeq/2EyWgcfVb62b/qib75oZ0m9W4uvRvqTiLdaGELoS8ohWGA==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.7.12.tgz",
+			"integrity": "sha512-BH9peuKjx2ikOxjnohdAH4ocRfC2NZQTXrJXsAdPOFja1iNHzBwpZe+/x+g8fO8a3WVrmBWad3814Hb/oGCICA==",
 			"cpu": [
 				"x64"
 			],
@@ -15227,9 +15204,9 @@
 			]
 		},
 		"node_modules/lefthook-windows-arm64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.7.7.tgz",
-			"integrity": "sha512-ZO45ynUnMPm+I8xGgmSc5BqtfByRJSRrhjXQ2lwNE9V+Zl3oMjCMPrs+3KLmrnKxi/k2bq/VHY86XvIhRo7o+g==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.7.12.tgz",
+			"integrity": "sha512-GlCNSpXAiBcCQ8jtcFGxkxGzqnsPzGWbx9HTYO7Xz1QjW56de311rdntyVIRl48nQ+Q76fVyEKAtsyQczvRN6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -15241,9 +15218,9 @@
 			]
 		},
 		"node_modules/lefthook-windows-x64": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.7.7.tgz",
-			"integrity": "sha512-z4/MxR+GMYZwgCxvLPGU4ebuXNUFdJrtrsAxMVbCw0LU/n7VCP+nfdaxcGO6ELqd4OOfpJCpBhzkvupFefmhhw==",
+			"version": "1.7.12",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.7.12.tgz",
+			"integrity": "sha512-9GeeQVUX7R8irJ5mf0Zzxn74ZTpy1LHqIGPRAmn9ELtkVdne/DGpCcGyKGVoJFbMInEaeDHGOnVjeQ9kgWB8Fw==",
 			"cpu": [
 				"x64"
 			],
@@ -17348,14 +17325,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-			"integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
+			"integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.45.3"
+				"playwright-core": "1.46.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -17368,9 +17345,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-			"integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
+			"integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -17439,9 +17416,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.40",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
-			"integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
+			"version": "8.4.41",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+			"integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -17468,9 +17445,9 @@
 			}
 		},
 		"node_modules/postcss-attribute-case-insensitive": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-6.0.3.tgz",
-			"integrity": "sha512-KHkmCILThWBRtg+Jn1owTnHPnFit4OkqS+eKiGEOPIGke54DCeYGJ6r0Fx/HjfE9M9kznApCLcU0DvnPchazMQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-7.0.0.tgz",
+			"integrity": "sha512-ETMUHIw67Kyv9Q81nden/NuJbRh+4/S963giXpfSLd5eaKK8kd1UdAHMVRV/NG/w/N6Cq8B0qZIZbZZWU/67+A==",
 			"dev": true,
 			"funding": [
 				{
@@ -17484,23 +17461,23 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-calc": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.0.0.tgz",
-			"integrity": "sha512-OmjhudoNTP0QleZCwl1i6NeBwN+5MZbY5ersLZz69mjJiDVv/p57RjRuKDkHeDWr4T+S97wQfsqRTNoDHB2e3g==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.0.1.tgz",
+			"integrity": "sha512-pp1Z3FxtxA+xHAoWXcOXgnBN1WPu4ZiJ5LWGjKyf9MMreagAsaTUtnqFK1y1sHhyJddAkYTPu6XSuLgb3oYCjw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.16",
+				"postcss-selector-parser": "^6.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -17527,9 +17504,9 @@
 			}
 		},
 		"node_modules/postcss-color-functional-notation": {
-			"version": "6.0.14",
-			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-6.0.14.tgz",
-			"integrity": "sha512-dNUX+UH4dAozZ8uMHZ3CtCNYw8fyFAmqqdcyxMr7PEdM9jLXV19YscoYO0F25KqZYhmtWKQ+4tKrIZQrwzwg7A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.0.tgz",
+			"integrity": "sha512-WjOCE1FJb2xIeFvF40CISn9yUMtzwkgjdbjXmWjbrC1wAgQiB763h7bsip9piGtAkbeM5Pi9hVIDSmtbWrlqLw==",
 			"dev": true,
 			"funding": [
 				{
@@ -17543,23 +17520,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-color-hex-alpha": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-9.0.4.tgz",
-			"integrity": "sha512-XQZm4q4fNFqVCYMGPiBjcqDhuG7Ey2xrl99AnDJMyr5eDASsAGalndVgHZF8i97VFNy1GQeZc4q2ydagGmhelQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-10.0.0.tgz",
+			"integrity": "sha512-1kervM2cnlgPs2a8Vt/Qbe5cQ++N7rkYo/2rz2BkqJZIHQwaVuJgQH38REHrAi4uM0b1fqxMkWYmese94iMp3w==",
 			"dev": true,
 			"funding": [
 				{
@@ -17573,20 +17550,20 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-color-rebeccapurple": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-9.0.3.tgz",
-			"integrity": "sha512-ruBqzEFDYHrcVq3FnW3XHgwRqVMrtEPLBtD7K2YmsLKVc2jbkxzzNEctJKsPCpDZ+LeMHLKRDoSShVefGc+CkQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-10.0.0.tgz",
+			"integrity": "sha512-JFta737jSP+hdAIEhk1Vs0q0YF5P8fFcj+09pweS8ktuGuZ8pPlykHsk6mPxZ8awDl4TrcxUqJo9l1IhVr/OjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -17600,24 +17577,24 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-colormin": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.1.tgz",
-			"integrity": "sha512-uszdT0dULt3FQs47G5UHCduYK+FnkLYlpu1HpWu061eGsKZ7setoG7kA+WC9NQLsOJf69D5TxGHgnAdRgylnFQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.2.tgz",
+			"integrity": "sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"caniuse-api": "^3.0.0",
 				"colord": "^2.9.3",
 				"postcss-value-parser": "^4.2.0"
@@ -17630,13 +17607,13 @@
 			}
 		},
 		"node_modules/postcss-convert-values": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.2.tgz",
-			"integrity": "sha512-MuZIF6HJ4izko07Q0TgW6pClalI4al6wHRNPkFzqQdwAwG7hPn0lA58VZdxyb2Vl5AYjJ1piO+jgF9EnTjQwQQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.3.tgz",
+			"integrity": "sha512-yJhocjCs2SQer0uZ9lXTMOwDowbxvhwFVrZeS6NPEij/XXthl73ggUmfwVvJM+Vaj5gtCKJV1jiUu4IhAUkX/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -17647,9 +17624,9 @@
 			}
 		},
 		"node_modules/postcss-custom-media": {
-			"version": "10.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-10.0.8.tgz",
-			"integrity": "sha512-V1KgPcmvlGdxTel4/CyQtBJEFhMVpEmRGFrnVtgfGIHj5PJX9vO36eFBxKBeJn+aCDTed70cc+98Mz3J/uVdGQ==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-11.0.0.tgz",
+			"integrity": "sha512-tZ4qTYSOqH7YFi8psEQB2v2zBRbbJex9FgPef2Qss8DlWxnYpBNHquvMmVBR8uIt6hW0+prDsg7UJDp6XLIf8w==",
 			"dev": true,
 			"funding": [
 				{
@@ -17663,22 +17640,22 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/cascade-layer-name-parser": "^1.0.13",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/media-query-list-parser": "^2.1.13"
+				"@csstools/cascade-layer-name-parser": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/media-query-list-parser": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-custom-properties": {
-			"version": "13.3.12",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-13.3.12.tgz",
-			"integrity": "sha512-oPn/OVqONB2ZLNqN185LDyaVByELAA/u3l2CS2TS16x2j2XsmV4kd8U49+TMxmUsEU9d8fB/I10E6U7kB0L1BA==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.0.tgz",
+			"integrity": "sha512-GD/suWYQAplXJujsyOswYP+oX9xs29eBNwGloPj4Ub+3/Rq1Set+ZeGmHJfN2Y2+x9vUxAX4eeNJFmtk6VBv4A==",
 			"dev": true,
 			"funding": [
 				{
@@ -17692,23 +17669,23 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/cascade-layer-name-parser": "^1.0.13",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/cascade-layer-name-parser": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-custom-selectors": {
-			"version": "7.1.12",
-			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-7.1.12.tgz",
-			"integrity": "sha512-ctIoprBMJwByYMGjXG0F7IT2iMF2hnamQ+aWZETyBM0aAlyaYdVZTeUkk8RB+9h9wP+NdN3f01lfvKl2ZSqC0g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-8.0.0.tgz",
+			"integrity": "sha512-nW6RWjH+jaWvXEgm/AzMhtVjMXcKmrTWsM/eJn/ujnJI5uEOPTxvl3eCFFCFKC2DiZcOP5HLH5EeX0DIemFzBQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -17722,22 +17699,22 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/cascade-layer-name-parser": "^1.0.13",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
+				"@csstools/cascade-layer-name-parser": "^2.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
 				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-dir-pseudo-class": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-8.0.1.tgz",
-			"integrity": "sha512-uULohfWBBVoFiZXgsQA24JV6FdKIidQ+ZqxOouhWwdE+qJlALbkS5ScB43ZTjPK+xUZZhlaO/NjfCt5h4IKUfw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-9.0.0.tgz",
+			"integrity": "sha512-T59BG9lURiXmhcJMyKbyjNAK3KCyEQYEhaz9GAETHXfIy9XbGQeyz+H0zIwRJlrP4KKRPJolNYe3QjQPemMjBA==",
 			"dev": true,
 			"funding": [
 				{
@@ -17751,23 +17728,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-discard-comments": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.1.tgz",
-			"integrity": "sha512-GVrQxUOhmle1W6jX2SvNLt4kmN+JYhV7mzI6BMnkAWR9DtVvg8e67rrV0NfdWhn7x1zxvzdWkMBPdBDCls+uwQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.2.tgz",
+			"integrity": "sha512-/Hje9Ls1IYcB9duELO/AyDUJI6aQVY3h5Rj1ziXgaLYCTi1iVBLnjg/TS0D6NszR/kDG6I86OwLmAYe+bvJjiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.1.0"
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -17777,9 +17754,9 @@
 			}
 		},
 		"node_modules/postcss-discard-duplicates": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.0.tgz",
-			"integrity": "sha512-bAnSuBop5LpAIUmmOSsuvtKAAKREB6BBIYStWUTGq8oG5q9fClDMMuY8i4UPI/cEcDx2TN+7PMnXYIId20UVDw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.1.tgz",
+			"integrity": "sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -17816,9 +17793,9 @@
 			}
 		},
 		"node_modules/postcss-double-position-gradients": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-5.0.7.tgz",
-			"integrity": "sha512-1xEhjV9u1s4l3iP5lRt1zvMjI/ya8492o9l/ivcxHhkO3nOz16moC4JpMxDUGrOs4R3hX+KWT7gKoV842cwRgg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.0.tgz",
+			"integrity": "sha512-JkIGah3RVbdSEIrcobqj4Gzq0h53GG4uqDPsho88SgY84WnpkTpI0k50MFK/sX7XqVisZ6OqUfFnoUO6m1WWdg==",
 			"dev": true,
 			"funding": [
 				{
@@ -17832,21 +17809,21 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-focus-visible": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-9.0.1.tgz",
-			"integrity": "sha512-N2VQ5uPz3Z9ZcqI5tmeholn4d+1H14fKXszpjogZIrFbhaq0zNAtq8sAnw6VLiqGbL8YBzsnu7K9bBkTqaRimQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-10.0.0.tgz",
+			"integrity": "sha512-GJjzvTj7JY+zN7wVBQ4osdKX53QLUdr6r2rSEkBUqrEMDKu3fHMHKOY9rirdirbHCx3IETnK25EtpPARR2KWNw==",
 			"dev": true,
 			"funding": [
 				{
@@ -17860,19 +17837,19 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-focus-within": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-8.0.1.tgz",
-			"integrity": "sha512-NFU3xcY/xwNaapVb+1uJ4n23XImoC86JNwkY/uduytSl2s9Ekc2EpzmRR63+ExitnW3Mab3Fba/wRPCT5oDILA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-9.0.0.tgz",
+			"integrity": "sha512-QwflAWUToNZvQLGbc4qJhrQO8yZ5617L6hSNzNWDoqRX4FoIh9fbJbEjy0nvFPciaaOoCaeqcxBwYPbFU0HvBw==",
 			"dev": true,
 			"funding": [
 				{
@@ -17886,10 +17863,10 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -17906,9 +17883,9 @@
 			}
 		},
 		"node_modules/postcss-gap-properties": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-5.0.1.tgz",
-			"integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-6.0.0.tgz",
+			"integrity": "sha512-Om0WPjEwiM9Ru+VhfEDPZJAKWUd0mV1HmNXqp2C29z80aQ2uP9UVhLc7e3aYMIor/S5cVhoPgYQ7RtfeZpYTRw==",
 			"dev": true,
 			"funding": [
 				{
@@ -17922,16 +17899,16 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-image-set-function": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-6.0.3.tgz",
-			"integrity": "sha512-i2bXrBYzfbRzFnm+pVuxVePSTCRiNmlfssGI4H0tJQvDue+yywXwUxe68VyzXs7cGtMaH6MCLY6IbCShrSroCw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-7.0.0.tgz",
+			"integrity": "sha512-QL7W7QNlZuzOwBTeXEmbVckNt1FSmhQtbMRvGGqqU4Nf4xk6KUEQhAoWuMzwbSv5jxiRiSZ5Tv7eiDB9U87znA==",
 			"dev": true,
 			"funding": [
 				{
@@ -17945,11 +17922,11 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/utilities": "^1.0.0",
+				"@csstools/utilities": "^2.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -18010,9 +17987,9 @@
 			}
 		},
 		"node_modules/postcss-lab-function": {
-			"version": "6.0.19",
-			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-6.0.19.tgz",
-			"integrity": "sha512-vwln/mgvFrotJuGV8GFhpAOu9iGf3pvTBr6dLPDmUcqVD5OsQpEFyQMAFTxSxWXGEzBj6ld4pZ/9GDfEpXvo0g==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.0.tgz",
+			"integrity": "sha512-Qyrlog4fAJcbwiWHiwkpDLlSRnvk2dFYqygQ29sMbhCoq6B/Jtj89u89VFNaAatW8KkDDAeNzVvabK9NBD9hJA==",
 			"dev": true,
 			"funding": [
 				{
@@ -18026,14 +18003,14 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^2.0.4",
-				"@csstools/css-parser-algorithms": "^2.7.1",
-				"@csstools/css-tokenizer": "^2.4.1",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/utilities": "^1.0.0"
+				"@csstools/css-color-parser": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.0",
+				"@csstools/css-tokenizer": "^3.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/utilities": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -18080,9 +18057,9 @@
 			}
 		},
 		"node_modules/postcss-logical": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-7.0.1.tgz",
-			"integrity": "sha512-8GwUQZE0ri0K0HJHkDv87XOLC8DE0msc+HoWLeKdtjDZEwpZ5xuK3QdV6FhmHSQW40LPkg43QzvATRAI3LsRkg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-8.0.0.tgz",
+			"integrity": "sha512-HpIdsdieClTjXLOyYdUPAX/XQASNIwdKt5hoZW08ZOAiI+tbV0ta1oclkpVkW5ANU+xJvk3KkA0FejkjGLXUkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -18099,7 +18076,7 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -18113,14 +18090,14 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss-merge-longhand": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.2.tgz",
-			"integrity": "sha512-06vrW6ZWi9qeP7KMS9fsa9QW56+tIMW55KYqF7X3Ccn+NI2pIgPV6gFfvXTMQ05H90Y5DvnCDPZ2IuHa30PMUg==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.3.tgz",
+			"integrity": "sha512-8waYomFxshdv6M9Em3QRM9MettRLDRcH2JQi2l0Z1KlYD/vhal3gbkeSES0NuACXOlZBB0V/B0AseHZaklzWOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
-				"stylehacks": "^7.0.2"
+				"stylehacks": "^7.0.3"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -18130,16 +18107,16 @@
 			}
 		},
 		"node_modules/postcss-merge-rules": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.2.tgz",
-			"integrity": "sha512-VAR47UNvRsdrTHLe7TV1CeEtF9SJYR5ukIB9U4GZyZOptgtsS20xSxy+k5wMrI3udST6O1XuIn7cjQkg7sDAAw==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.3.tgz",
+			"integrity": "sha512-2eSas2p3voPxNfdI5sQrvIkMaeUHpVc3EezgVs18hz/wRTQAC9U99tp9j3W5Jx9/L3qHkEDvizEx/LdnmumIvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"caniuse-api": "^3.0.0",
 				"cssnano-utils": "^5.0.0",
-				"postcss-selector-parser": "^6.1.0"
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -18183,13 +18160,13 @@
 			}
 		},
 		"node_modules/postcss-minify-params": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.1.tgz",
-			"integrity": "sha512-e+Xt8xErSRPgSRFxHeBCSxMiO8B8xng7lh8E0A5ep1VfwYhY8FXhu4Q3APMjgx9YDDbSp53IBGENrzygbUvgUQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.2.tgz",
+			"integrity": "sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"cssnano-utils": "^5.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -18201,14 +18178,14 @@
 			}
 		},
 		"node_modules/postcss-minify-selectors": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.2.tgz",
-			"integrity": "sha512-dCzm04wqW1uqLmDZ41XYNBJfjgps3ZugDpogAmJXoCb5oCiTzIX4oPXXKxDpTvWOnKxQKR4EbV4ZawJBLcdXXA==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.3.tgz",
+			"integrity": "sha512-SxTgUQSgBk6wEqzQZKEv1xQYIp9UBju6no9q+npohzSdhuSICQdkqmD1UMKkZWItS3olJSJMDDEY9WOJ5oGJew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
-				"postcss-selector-parser": "^6.1.0"
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -18310,9 +18287,9 @@
 			}
 		},
 		"node_modules/postcss-nesting": {
-			"version": "12.1.5",
-			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.5.tgz",
-			"integrity": "sha512-N1NgI1PDCiAGWPTYrwqm8wpjv0bgDmkYHH72pNsqTCv9CObxjxftdYu6AKtGN+pnJa7FQjMm3v4sp8QJbFsYdQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.0.tgz",
+			"integrity": "sha512-TCGQOizyqvEkdeTPM+t6NYwJ3EJszYE/8t8ILxw/YoeUvz2rz7aM8XTAmBWh9/DJjfaaabL88fWrsVHSPF2zgA==",
 			"dev": true,
 			"funding": [
 				{
@@ -18326,12 +18303,12 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/selector-resolve-nested": "^1.1.0",
-				"@csstools/selector-specificity": "^3.1.1",
+				"@csstools/selector-resolve-nested": "^2.0.0",
+				"@csstools/selector-specificity": "^4.0.0",
 				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -18431,13 +18408,13 @@
 			}
 		},
 		"node_modules/postcss-normalize-unicode": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.1.tgz",
-			"integrity": "sha512-PTPGdY9xAkTw+8ZZ71DUePb7M/Vtgkbbq+EoI33EuyQEzbKemEQMhe5QSr0VP5UfZlreANDPxSfcdSprENcbsg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.2.tgz",
+			"integrity": "sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -18520,9 +18497,9 @@
 			}
 		},
 		"node_modules/postcss-overflow-shorthand": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-5.0.1.tgz",
-			"integrity": "sha512-XzjBYKLd1t6vHsaokMV9URBt2EwC9a7nDhpQpjoPk2HRTSQfokPfyAS/Q7AOrzUu6q+vp/GnrDBGuj/FCaRqrQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-6.0.0.tgz",
+			"integrity": "sha512-BdDl/AbVkDjoTofzDQnwDdm/Ym6oS9KgmO7Gr+LHYjNWJ6ExORe4+3pcLQsLA9gIROMkiGVjjwZNoL/mpXHd5Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -18539,7 +18516,7 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -18556,9 +18533,9 @@
 			}
 		},
 		"node_modules/postcss-place": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-9.0.1.tgz",
-			"integrity": "sha512-JfL+paQOgRQRMoYFc2f73pGuG/Aw3tt4vYMR6UA3cWVMxivviPTnMFnFTczUJOA4K2Zga6xgQVE+PcLs64WC8Q==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-10.0.0.tgz",
+			"integrity": "sha512-5EBrMzat2pPAxQNWYavwAfoKfYcTADJ8AXGVPcUZ2UkNloUTWzJQExgrzrDkh3EKzmAx1evfTAzF9I8NGcc+qw==",
 			"dev": true,
 			"funding": [
 				{
@@ -18575,16 +18552,16 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-preset-env": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-9.6.0.tgz",
-			"integrity": "sha512-Lxfk4RYjUdwPCYkc321QMdgtdCP34AeI94z+/8kVmqnTIlD4bMRQeGcMZgwz8BxHrzQiFXYIR5d7k/9JMs2MEA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.0.0.tgz",
+			"integrity": "sha512-zoLkIGK30hkLhHVD6jNqcO6gDVDzyo10s42XG++Gsy9z6gk1X/UpI2Zn28ylGD9VnQSSdQMzuk535rRq2JmWkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -18598,79 +18575,79 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/postcss-cascade-layers": "^4.0.6",
-				"@csstools/postcss-color-function": "^3.0.19",
-				"@csstools/postcss-color-mix-function": "^2.0.19",
-				"@csstools/postcss-content-alt-text": "^1.0.0",
-				"@csstools/postcss-exponential-functions": "^1.0.9",
-				"@csstools/postcss-font-format-keywords": "^3.0.2",
-				"@csstools/postcss-gamut-mapping": "^1.0.11",
-				"@csstools/postcss-gradients-interpolation-method": "^4.0.20",
-				"@csstools/postcss-hwb-function": "^3.0.18",
-				"@csstools/postcss-ic-unit": "^3.0.7",
-				"@csstools/postcss-initial": "^1.0.1",
-				"@csstools/postcss-is-pseudo-class": "^4.0.8",
-				"@csstools/postcss-light-dark-function": "^1.0.8",
-				"@csstools/postcss-logical-float-and-clear": "^2.0.1",
-				"@csstools/postcss-logical-overflow": "^1.0.1",
-				"@csstools/postcss-logical-overscroll-behavior": "^1.0.1",
-				"@csstools/postcss-logical-resize": "^2.0.1",
-				"@csstools/postcss-logical-viewport-units": "^2.0.11",
-				"@csstools/postcss-media-minmax": "^1.1.8",
-				"@csstools/postcss-media-queries-aspect-ratio-number-values": "^2.0.11",
-				"@csstools/postcss-nested-calc": "^3.0.2",
-				"@csstools/postcss-normalize-display-values": "^3.0.2",
-				"@csstools/postcss-oklab-function": "^3.0.19",
-				"@csstools/postcss-progressive-custom-properties": "^3.3.0",
-				"@csstools/postcss-relative-color-syntax": "^2.0.19",
-				"@csstools/postcss-scope-pseudo-class": "^3.0.1",
-				"@csstools/postcss-stepped-value-functions": "^3.0.10",
-				"@csstools/postcss-text-decoration-shorthand": "^3.0.7",
-				"@csstools/postcss-trigonometric-functions": "^3.0.10",
-				"@csstools/postcss-unset-value": "^3.0.1",
+				"@csstools/postcss-cascade-layers": "^5.0.0",
+				"@csstools/postcss-color-function": "^4.0.0",
+				"@csstools/postcss-color-mix-function": "^3.0.0",
+				"@csstools/postcss-content-alt-text": "^2.0.0",
+				"@csstools/postcss-exponential-functions": "^2.0.0",
+				"@csstools/postcss-font-format-keywords": "^4.0.0",
+				"@csstools/postcss-gamut-mapping": "^2.0.0",
+				"@csstools/postcss-gradients-interpolation-method": "^5.0.0",
+				"@csstools/postcss-hwb-function": "^4.0.0",
+				"@csstools/postcss-ic-unit": "^4.0.0",
+				"@csstools/postcss-initial": "^2.0.0",
+				"@csstools/postcss-is-pseudo-class": "^5.0.0",
+				"@csstools/postcss-light-dark-function": "^2.0.0",
+				"@csstools/postcss-logical-float-and-clear": "^3.0.0",
+				"@csstools/postcss-logical-overflow": "^2.0.0",
+				"@csstools/postcss-logical-overscroll-behavior": "^2.0.0",
+				"@csstools/postcss-logical-resize": "^3.0.0",
+				"@csstools/postcss-logical-viewport-units": "^3.0.0",
+				"@csstools/postcss-media-minmax": "^2.0.0",
+				"@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.0",
+				"@csstools/postcss-nested-calc": "^4.0.0",
+				"@csstools/postcss-normalize-display-values": "^4.0.0",
+				"@csstools/postcss-oklab-function": "^4.0.0",
+				"@csstools/postcss-progressive-custom-properties": "^4.0.0",
+				"@csstools/postcss-relative-color-syntax": "^3.0.0",
+				"@csstools/postcss-scope-pseudo-class": "^4.0.0",
+				"@csstools/postcss-stepped-value-functions": "^4.0.0",
+				"@csstools/postcss-text-decoration-shorthand": "^4.0.0",
+				"@csstools/postcss-trigonometric-functions": "^4.0.0",
+				"@csstools/postcss-unset-value": "^4.0.0",
 				"autoprefixer": "^10.4.19",
 				"browserslist": "^4.23.1",
-				"css-blank-pseudo": "^6.0.2",
-				"css-has-pseudo": "^6.0.5",
-				"css-prefers-color-scheme": "^9.0.1",
+				"css-blank-pseudo": "^7.0.0",
+				"css-has-pseudo": "^7.0.0",
+				"css-prefers-color-scheme": "^10.0.0",
 				"cssdb": "^8.1.0",
-				"postcss-attribute-case-insensitive": "^6.0.3",
+				"postcss-attribute-case-insensitive": "^7.0.0",
 				"postcss-clamp": "^4.1.0",
-				"postcss-color-functional-notation": "^6.0.14",
-				"postcss-color-hex-alpha": "^9.0.4",
-				"postcss-color-rebeccapurple": "^9.0.3",
-				"postcss-custom-media": "^10.0.8",
-				"postcss-custom-properties": "^13.3.12",
-				"postcss-custom-selectors": "^7.1.12",
-				"postcss-dir-pseudo-class": "^8.0.1",
-				"postcss-double-position-gradients": "^5.0.7",
-				"postcss-focus-visible": "^9.0.1",
-				"postcss-focus-within": "^8.0.1",
+				"postcss-color-functional-notation": "^7.0.0",
+				"postcss-color-hex-alpha": "^10.0.0",
+				"postcss-color-rebeccapurple": "^10.0.0",
+				"postcss-custom-media": "^11.0.0",
+				"postcss-custom-properties": "^14.0.0",
+				"postcss-custom-selectors": "^8.0.0",
+				"postcss-dir-pseudo-class": "^9.0.0",
+				"postcss-double-position-gradients": "^6.0.0",
+				"postcss-focus-visible": "^10.0.0",
+				"postcss-focus-within": "^9.0.0",
 				"postcss-font-variant": "^5.0.0",
-				"postcss-gap-properties": "^5.0.1",
-				"postcss-image-set-function": "^6.0.3",
-				"postcss-lab-function": "^6.0.19",
-				"postcss-logical": "^7.0.1",
-				"postcss-nesting": "^12.1.5",
+				"postcss-gap-properties": "^6.0.0",
+				"postcss-image-set-function": "^7.0.0",
+				"postcss-lab-function": "^7.0.0",
+				"postcss-logical": "^8.0.0",
+				"postcss-nesting": "^13.0.0",
 				"postcss-opacity-percentage": "^2.0.0",
-				"postcss-overflow-shorthand": "^5.0.1",
+				"postcss-overflow-shorthand": "^6.0.0",
 				"postcss-page-break": "^3.0.4",
-				"postcss-place": "^9.0.1",
-				"postcss-pseudo-class-any-link": "^9.0.2",
+				"postcss-place": "^10.0.0",
+				"postcss-pseudo-class-any-link": "^10.0.0",
 				"postcss-replace-overflow-wrap": "^4.0.0",
-				"postcss-selector-not": "^7.0.2"
+				"postcss-selector-not": "^8.0.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-pseudo-class-any-link": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-9.0.2.tgz",
-			"integrity": "sha512-HFSsxIqQ9nA27ahyfH37cRWGk3SYyQLpk0LiWw/UGMV4VKT5YG2ONee4Pz/oFesnK0dn2AjcyequDbIjKJgB0g==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-10.0.0.tgz",
+			"integrity": "sha512-bde8VE08Gq3ekKDq2BQ0ESOjNX54lrFDK3U9zABPINaqHblbZL/4Wfo5Y2vk6U64yVd/sjDwTzuiisFBpGNNIQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -18684,23 +18661,23 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"node_modules/postcss-reduce-initial": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.1.tgz",
-			"integrity": "sha512-0JDUSV4bGB5FGM5g8MkS+rvqKukJZ7OTHw/lcKn7xPNqeaqJyQbUO8/dJpvyTpaVwPsd3Uc33+CfNzdVowp2WA==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.2.tgz",
+			"integrity": "sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
+				"browserslist": "^4.23.3",
 				"caniuse-api": "^3.0.0"
 			},
 			"engines": {
@@ -18737,9 +18714,9 @@
 			}
 		},
 		"node_modules/postcss-resolve-nested-selector": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.4.tgz",
-			"integrity": "sha512-R6vHqZWgVnTAPq0C+xjyHfEZqfIYboCBVSy24MjxEDm+tIh1BU4O6o7DP7AA7kHzf136d+Qc5duI4tlpHjixDw==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.5.tgz",
+			"integrity": "sha512-tum2m18S22ZSNjXatMG0FSk5ZL83pTttymeJx5Gzxg7RU0s1jNDU9rXltro4osQrukjyNormcb07IEjqEyPNaA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -18788,9 +18765,9 @@
 			}
 		},
 		"node_modules/postcss-selector-not": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-7.0.2.tgz",
-			"integrity": "sha512-/SSxf/90Obye49VZIfc0ls4H0P6i6V1iHv0pzZH8SdgvZOPFkF37ef1r5cyWcMflJSFJ5bfuoluTnFnBBFiuSA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-8.0.0.tgz",
+			"integrity": "sha512-g/juh7A83GWc3+kWL8BiS3YUIJb3XNqIVKz1kGvgN3OhoGCsPncy1qo/+q61tjy5r87OxBhSY1+hcH3yOhEW+g==",
 			"dev": true,
 			"funding": [
 				{
@@ -18804,10 +18781,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.13"
+				"postcss-selector-parser": "^6.1.0"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -18862,13 +18839,13 @@
 			}
 		},
 		"node_modules/postcss-unique-selectors": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.1.tgz",
-			"integrity": "sha512-MH7QE/eKUftTB5ta40xcHLl7hkZjgDFydpfTK+QWXeHxghVt3VoPqYL5/G+zYZPPIs+8GuqFXSTgxBSoB1RZtQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.2.tgz",
+			"integrity": "sha512-CjSam+7Vf8cflJQsHrMS0P2hmy9u0+n/P001kb5eAszLmhjMqrt/i5AqQuNFihhViwDvEAezqTmXqaYXL2ugMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.1.0"
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -21430,14 +21407,14 @@
 			"license": "ISC"
 		},
 		"node_modules/stylehacks": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.2.tgz",
-			"integrity": "sha512-HdkWZS9b4gbgYTdMg4gJLmm7biAUug1qTqXjS+u8X+/pUd+9Px1E+520GnOW3rST9MNsVOVpsJG+mPHNosxjOQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.3.tgz",
+			"integrity": "sha512-4DqtecvI/Nd+2BCvW9YEF6lhBN5UM50IJ1R3rnEAhBwbCKf4VehRf+uqvnVArnBayjYD/WtT3g0G/HSRxWfTRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.1",
-				"postcss-selector-parser": "^6.1.0"
+				"browserslist": "^4.23.3",
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -21845,9 +21822,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.31.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
-			"integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
+			"version": "5.31.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
+			"integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -22488,9 +22465,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
+			"integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -22859,9 +22836,9 @@
 			}
 		},
 		"node_modules/web-vitals": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.2.tgz",
-			"integrity": "sha512-nYfoOqb4EmElljyXU2qdeE76KsvoHdftQKY4DzA9Aw8DervCg2bG634pHLrJ/d6+B4mE3nWTSJv8Mo7B2mbZkw==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.3.tgz",
+			"integrity": "sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -23394,14 +23371,14 @@
 			}
 		},
 		"node_modules/which-builtin-type": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
-			"integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+			"integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"function.prototype.name": "^1.1.5",
-				"has-tostringtag": "^1.0.0",
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
 				"is-async-function": "^2.0.0",
 				"is-date-object": "^1.0.5",
 				"is-finalizationregistry": "^1.0.2",
@@ -23410,8 +23387,8 @@
 				"is-weakref": "^1.0.2",
 				"isarray": "^2.0.5",
 				"which-boxed-primitive": "^1.0.2",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.9"
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.15"
 			},
 			"engines": {
 				"node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
 	},
 	"browserslist": [
 		"last 2 versions",
-		"safari >= 16",
-		"ios >= 16",
 		"not op_mini all",
 		"not dead"
 	],

--- a/package.json
+++ b/package.json
@@ -26,18 +26,18 @@
 		"coreBlockTemplatesDir": "../../../../../dev/templates"
 	},
 	"devDependencies": {
-		"@csstools/postcss-global-data": "^2.1.0",
-		"@wordpress/create-block": "^4.47.0",
-		"@wordpress/scripts": "^28.4.0",
+		"@csstools/postcss-global-data": "^3.0.0",
+		"@wordpress/create-block": "^4.48.0",
+		"@wordpress/scripts": "^28.5.0",
 		"browser-sync": "^3.0.2",
 		"browser-sync-v3-webpack-plugin": "^0.1.0",
-		"cssnano": "^7.0.3",
+		"cssnano": "^7.0.5",
 		"fast-glob": "^3.3.1",
-		"lefthook": "^1.7.7",
+		"lefthook": "^1.7.12",
 		"postcss-import": "^16.1.0",
 		"postcss-inline-svg": "^6.0.0",
 		"postcss-mixins": "^10.0.1",
-		"postcss-preset-env": "^9.5.14",
+		"postcss-preset-env": "^10.0.0",
 		"webpack-remove-empty-scripts": "^1.0.4"
 	},
 	"scripts": {


### PR DESCRIPTION
## What does this do/fix?
- Some NPM packages didn't seem to update properly on my last PR #149 . Doing that again.
- Updated the supported browsers to remove remove Safari exceptions. [iOS 16 versions are now well under 5% usage in the US](https://gs.statcounter.com/ios-version-market-share/all/united-states-of-america). Note that this change is also reflected on our public [Testing Policy](https://tri.be/testing-policy/).
## QA

Links to relevant issues
- [MOOSE-140](https://moderntribe.atlassian.net/browse/MOOSE-140)


[MOOSE-140]: https://moderntribe.atlassian.net/browse/MOOSE-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ