### PR TITLE
BE: Update editor style enqueues to use a version param to allow cache busting

### DIFF
--- a/tests/_data/editor_asset_test.php
+++ b/tests/_data/editor_asset_test.php
@@ -1,0 +1,2 @@
+<?php
+return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-element', 'wp-hooks', 'wp-i18n'), 'version' => '024bef6fb3a0bc82cb17');

--- a/tests/acceptance/ExampleCest.php
+++ b/tests/acceptance/ExampleCest.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+class ExampleCest {
+    public function test_it_works( AcceptanceTester $I ): void {
+        $I->amOnPage('/');
+    }
+
+}

--- a/tests/wpunit/BlockBaseWpUnitTest.php
+++ b/tests/wpunit/BlockBaseWpUnitTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+class BlockBaseWpUnitTest extends \Codeception\TestCase\WPTestCase {
+
+    use \Tribe\Plugin\Assets\Traits\Assets;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $block_dir    = get_template_directory() . '/dist/blocks/core/button';
+        $editor_asset = $block_dir . '/editor.asset.php';
+        mkdir( $block_dir, 0777, true );
+
+        $editor_asset_content = file_get_contents( __DIR__ . '/../_data/editor_asset_test.php' );
+        $file_handler         = fopen( $editor_asset, 'w' );
+        fwrite( $file_handler, $editor_asset_content );
+        fclose( $file_handler );
+    }
+
+    public function test_editor_styles_can_get_version_from_asset_php()
+    {
+        $args = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/core/button/editor.asset.php" ) );
+        self::assertArrayHasKey( 'version', $args );
+        $version = $args['version'] ?? false;
+        self::assertEquals( '024bef6fb3a0bc82cb17', $version );
+    }
+
+    protected function tearDown(): void {
+        parent::tearDown();
+
+        $block_dir    = get_template_directory() . '/dist/blocks/core/button';
+        $editor_asset = $block_dir . '/editor.asset.php';
+
+        unlink( $editor_asset );
+        rmdir( $block_dir );
+    }
+
+}

--- a/wp-content/plugins/core/src/Blocks/Block_Base.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Base.php
@@ -72,11 +72,17 @@ abstract class Block_Base {
 	public function enqueue_core_block_public_styles(): void {
 		$handle   = $this->get_block_style_handle();
 		$path     = $this->get_block_path();
+		$args     = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/index.asset.php" ) );
+		$version  = $args['version'] ?? false;
 		$src_path = get_theme_file_path( "dist/blocks/$path/style-index.css" );
 		$src      = get_theme_file_uri( "dist/blocks/$path/style-index.css" );
 
 		if ( ! file_exists( $src_path ) ) {
 			return;
+		}
+
+		if ( ! empty( $version ) ) {
+			$src = $src . '?ver=' . $version;
 		}
 
 		wp_add_inline_style( $handle, file_get_contents( $src_path ) );
@@ -92,11 +98,17 @@ abstract class Block_Base {
 	 */
 	public function enqueue_core_block_editor_styles(): void {
 		$path            = $this->get_block_path();
+		$args            = $this->get_asset_file_args( get_theme_file_path( "dist/blocks/$path/editor.asset.php" ) );
+		$version         = $args['version'] ?? false;
 		$editor_src_path = get_theme_file_path( "dist/blocks/$path/editor.css" );
 		$editor_src      = get_theme_file_uri( "dist/blocks/$path/editor.css" );
 
 		if ( ! file_exists( $editor_src_path ) ) {
 			return;
+		}
+
+		if ( ! empty( $version ) ) {
+			$editor_src = $editor_src . '?ver=' . $version;
 		}
 
 		add_editor_style( $editor_src );


### PR DESCRIPTION
## What does this do/fix?

Add version to the editor styles to allow cache busting
Add example stub for acceptance tests.The `Cest` is correct terminology here. Codecept use such names in order to find tests
Add simple testing for grabbing editor styles meta from file 

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/MOOSE-114