### PR TITLE
Add PR sync as a trigger for code quality checks.

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this do/fix?
Our code quality checks aren't running on PR sync, but we expect them to pass before a PR can be merged.
