### PR TITLE
Fix/moose 169/remove unnecessary theme support calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ Thumbs.db
 .DS_Store
 .idea
 pimple.json
-.phpstorm.meta.php
 
 # IDE generated files #
 ######################

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+// .phpstorm.meta.php
+namespace PHPSTORM_META {
+
+    override( \Psr\Container\ContainerInterface::get( 0 ), map( [
+        '' => '@',
+    ] ) );
+    override( \DI\Container::get( 0 ), map( [
+        '' => '@',
+    ] ) );
+    override( \DI\FactoryInterface::make( 0 ), map( [
+        '' => '@',
+    ] ) );
+    override( \DI\Container::make( 0 ), map( [
+        '' => '@',
+    ] ) );
+}

--- a/wp-content/plugins/core/src/Theme_Config/Theme_Support.php
+++ b/wp-content/plugins/core/src/Theme_Config/Theme_Support.php
@@ -8,10 +8,6 @@ class Theme_Support {
 	 * @action after_setup_theme
 	 */
 	public function add_theme_supports(): void {
-		$this->support_thumbnails();
-		$this->support_title_tag();
-		$this->support_responsive_embeds();
-		$this->support_html5();
 		$this->remove_support_block_widgets();
 	}
 
@@ -22,43 +18,15 @@ class Theme_Support {
 		remove_theme_support( 'core-block-patterns' );
 	}
 
+	/**
+	 * Disable Openverse Media Category.
+	 *
+	 * @param array $settings
+	 */
 	public function disable_openverse_media_category( array $settings ): array {
 		$settings['enableOpenverseMediaCategory'] = false;
 
 		return $settings;
-	}
-
-	/**
-	 * Supports: enable Featured Images
-	 */
-	private function support_thumbnails(): void {
-		add_theme_support( 'post-thumbnails' );
-	}
-
-	/**
-	 * Supports: enable Document Title Tag
-	 */
-	private function support_title_tag(): void {
-		add_theme_support( 'title-tag' );
-	}
-
-	private function support_responsive_embeds(): void {
-		add_theme_support( 'responsive-embeds' );
-	}
-
-	/**
-	 * Support: switch core WordPress markup to output valid HTML5
-	 */
-	private function support_html5(): void {
-		add_theme_support( 'html5', [
-			'search-form',
-			'comment-form',
-			'comment-list',
-			'gallery',
-			'caption',
-			'script',
-			'style',
-		] );
 	}
 
 	/**


### PR DESCRIPTION
## What does this do/fix?

Block themes already apply most traditional theme_support features in WordPress.  From [FSE.com:](https://fullsiteediting.com/lessons/creating-block-based-themes/#h-theme-support)

> The following theme support is automatically enabled for block themes:
> post-thumbnails, editor-styles, responsive-embeds, automatic-feed-links, html5 styles, and html5 scripts.
> 
> You do not need to include `add_theme_support( 'title-tag' )` in the setup function, because WordPress already renders the title tag for full site editing themes.

And, adding `title-tag` theme  support actually causes [a bug in Yoast SEO to surface](https://tribe.slack.com/archives/C01CY7418GY/p1732200411511529) where the title is erroneously injected twice into each document.

This PR removes unnecessary `add_theme_support()` calls from Moose.

Additionally, this PR adds the `.phpstorm.meta.php` file to [tell storm how to handle our DI container class mapping](https://tribe.slack.com/archives/C01CY7418GY/p1732299018138219?thread_ts=1732298320.316839&cid=C01CY7418GY).

## QA

Links to relevant issues
- [MOOSE-169](https://moderntribe.atlassian.net/browse/MOOSE-169)

Screenshots/video:
- [After fix](http://p.tri.be/i/A2Rvwh)


[MOOSE-169]: https://moderntribe.atlassian.net/browse/MOOSE-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ