### PR TITLE
Chore/moose 171/lando updates

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: moose
 recipe: wordpress
 config:
   php: '8.3'
-  database: mariadb:10.11
+  database: mariadb:11.5
   composer_version: 2-latest
   via: nginx
   xdebug: false

--- a/.lando.yml
+++ b/.lando.yml
@@ -12,12 +12,21 @@ services:
     overrides:
       environment:
         - XDEBUG_TRIGGER=1
-  mailhog:
-    type: mailhog
-    portforward: true
-    hogfrom:
-      - appserver_nginx
-      - appserver
+
+# Enabling MailHog will cause an error on start: `/bin/sh: 1: curl: not found`.
+# Related GH Issue: https://github.com/lando/mailhog/issues/35
+#
+# The error doesn't actually cause any issues, but prevents lando from starting cleanly.
+# If you need access to email from this site, enable the Mailhog service below.
+# Otherwise, It's safe to keep this service disabled.
+
+#  mailhog:
+#    type: mailhog
+#    portforward: true
+#    hogfrom:
+#      - appserver_nginx
+#      - appserver
+
 tooling:
   xdebug-on:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,8 +1,8 @@
 name: moose
 recipe: wordpress
 config:
-  php: '8.2'
-  database: mariadb
+  php: '8.3'
+  database: mariadb:10.11
   composer_version: 2-latest
   via: nginx
   xdebug: false

--- a/composer.json
+++ b/composer.json
@@ -96,8 +96,7 @@
 		"php-stubs/wordpress-tests-stubs": "^6.2",
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan": "^1.10",
-		"szepeviktor/phpstan-wordpress": "^1.3",
-		"wpackagist-plugin/debug-bar": "^1.1"
+		"szepeviktor/phpstan-wordpress": "^1.3"
 	},
 	"require": {
 		"php": "^8.2",
@@ -119,6 +118,7 @@
 		"vinkla/extended-acf": "^13.6",
 		"vlucas/phpdotenv": "^5.5",
 		"wp-cli/wp-cli-bundle": "^2.8",
+		"wpackagist-plugin/debug-bar": "^1.1",
 		"wpackagist-plugin/disable-emojis": "1.7.6",
 		"wpackagist-plugin/duracelltomi-google-tag-manager": "1.20.2",
 		"wpackagist-plugin/limit-login-attempts-reloaded": "2.26.16",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 			"phpstan/extension-installer": true
 		},
 		"platform": {
-			"php": "8.2"
+			"php": "8.3"
 		},
 		"platform-check": false
 	},
@@ -99,7 +99,7 @@
 		"szepeviktor/phpstan-wordpress": "^1.3"
 	},
 	"require": {
-		"php": "^8.2",
+		"php": "^8.3",
 		"ext-exif": "*",
 		"ext-gd": "*",
 		"ext-intl": "*",

--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,6 @@
 		"wpackagist-plugin/seo-by-rank-math": "1.0.232",
 		"wpackagist-plugin/social-sharing-block": "^1.0",
 		"wpackagist-plugin/user-switching": "1.9.0",
-		"wpackagist-plugin/wp-tota11y": "^1.2",
 		"wpengine/advanced-custom-fields-pro": "6.3.11"
 	},
 	"extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5697d4fec79deffd449517efc49edf4c",
+    "content-hash": "69c9aa45efae44f5f2736781d0ba0626",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.330.0",
+            "version": "3.332.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "dd1b65a4329f91d5e282a92fab2be7bdf6e2adea"
+                "reference": "3b4972a465b66fe3da461a3febdcc363954a0969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/dd1b65a4329f91d5e282a92fab2be7bdf6e2adea",
-                "reference": "dd1b65a4329f91d5e282a92fab2be7bdf6e2adea",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3b4972a465b66fe3da461a3febdcc363954a0969",
+                "reference": "3b4972a465b66fe3da461a3febdcc363954a0969",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 "nette/neon": "^2.3",
                 "paragonie/random_compat": ">= 2",
                 "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
-                "psr/cache": "^1.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0",
                 "yoast/phpunit-polyfills": "^1.0"
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.330.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.332.0"
             },
-            "time": "2024-11-22T19:10:26+00:00"
+            "time": "2024-12-02T03:48:16+00:00"
         },
         {
             "name": "block-editor-custom-alignments/block-editor-custom-alignments",
@@ -172,16 +172,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.3",
+            "version": "1.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2"
+                "reference": "bc0593537a463e55cadf45fd938d23b75095b7e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
-                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/bc0593537a463e55cadf45fd938d23b75095b7e1",
+                "reference": "bc0593537a463e55cadf45fd938d23b75095b7e1",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +228,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.3"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.4"
             },
             "funding": [
                 {
@@ -244,20 +244,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T10:15:26+00:00"
+            "time": "2024-11-27T15:35:25+00:00"
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "98bbf6780e56e0fd2404fe4b82eb665a0f93b783"
+                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/98bbf6780e56e0fd2404fe4b82eb665a0f93b783",
-                "reference": "98bbf6780e56e0fd2404fe4b82eb665a0f93b783",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
+                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
                 "shasum": ""
             },
             "require": {
@@ -266,10 +266,10 @@
                 "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.6",
-                "phpstan/phpstan-deprecation-rules": "^1",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
                 "phpunit/phpunit": "^8",
                 "symfony/filesystem": "^5.4 || ^6"
             },
@@ -301,7 +301,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.4.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -317,7 +317,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-03T18:14:00+00:00"
+            "time": "2024-11-25T16:11:06+00:00"
         },
         {
             "name": "composer/composer",
@@ -374,13 +374,13 @@
             ],
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "2.8-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "phpstan/rules.neon"
                     ]
+                },
+                "branch-alias": {
+                    "dev-main": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1686,32 +1686,32 @@
         },
         {
             "name": "johnbillion/args",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/args.git",
-                "reference": "9db0a12de9f1198db0f3f319644a3a216a48fe68"
+                "reference": "ef9b110c4379ded08300c5484e4fa67455697c5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/args/zipball/9db0a12de9f1198db0f3f319644a3a216a48fe68",
-                "reference": "9db0a12de9f1198db0f3f319644a3a216a48fe68",
+                "url": "https://api.github.com/repos/johnbillion/args/zipball/ef9b110c4379ded08300c5484e4fa67455697c5b",
+                "reference": "ef9b110c4379ded08300c5484e4fa67455697c5b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0"
             },
             "require-dev": {
-                "ergebnis/json-printer": "^3.2",
-                "ergebnis/phpstan-rules": "^1.0",
+                "ergebnis/json-printer": "3.7.0",
+                "ergebnis/phpstan-rules": "1.0.0",
                 "humanmade/coding-standards": "1.2.1",
                 "johnbillion/falsey-assertequals-detector": "^3",
                 "phpdocumentor/reflection": "~4.0 || ~5.0",
-                "phpstan/phpstan": "1.12.5",
-                "phpstan/phpstan-phpunit": "1.4.0",
+                "phpstan/phpstan": "1.12.12",
+                "phpstan/phpstan-phpunit": "1.4.1",
                 "phpstan/phpstan-strict-rules": "1.6.1",
                 "phpunit/phpunit": "^9.0",
-                "roots/wordpress-core-installer": "^1.0.0",
+                "roots/wordpress-core-installer": "1.100.0",
                 "roots/wordpress-full": "6.7",
                 "szepeviktor/phpstan-wordpress": "1.3.5"
             },
@@ -1719,249 +1719,249 @@
             "extra": {
                 "args-shapes": [
                     {
-                        "function": "\\get_categories()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/category.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/category.php"
+                        "function": "\\get_categories()"
                     },
                     {
-                        "function": "\\get_comments()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/comment.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/comment.php"
+                        "function": "\\get_comments()"
                     },
                     {
-                        "function": "\\get_posts()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/post.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/post.php"
+                        "function": "\\get_posts()"
                     },
                     {
-                        "function": "\\get_tags()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/category.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/category.php"
+                        "function": "\\get_tags()"
                     },
                     {
-                        "function": "\\get_terms()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\get_terms()"
                     },
                     {
-                        "function": "\\get_users()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/user.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/user.php"
+                        "function": "\\get_users()"
                     },
                     {
-                        "function": "\\paginate_links()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/general-template.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/general-template.php"
+                        "function": "\\paginate_links()"
                     },
                     {
-                        "function": "\\register_block_type()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/blocks.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/blocks.php"
+                        "function": "\\register_block_type()"
                     },
                     {
-                        "function": "\\register_meta()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/meta.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/meta.php"
+                        "function": "\\register_meta()"
                     },
                     {
-                        "function": "\\register_post_meta()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/post.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/post.php"
+                        "function": "\\register_post_meta()"
                     },
                     {
-                        "function": "\\register_post_status()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/post.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/post.php"
+                        "function": "\\register_post_status()"
                     },
                     {
-                        "function": "\\register_post_type()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/post.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/post.php"
+                        "function": "\\register_post_type()"
                     },
                     {
-                        "function": "\\register_rest_field()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/rest-api.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/rest-api.php"
+                        "function": "\\register_rest_field()"
                     },
                     {
-                        "function": "\\register_setting()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/option.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/option.php"
+                        "function": "\\register_setting()"
                     },
                     {
-                        "function": "\\register_taxonomy()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\register_taxonomy()"
                     },
                     {
-                        "function": "\\register_term_meta()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\register_term_meta()"
                     },
                     {
-                        "function": "\\wp_count_terms()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\wp_count_terms()"
                     },
                     {
-                        "function": "\\wp_die()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/functions.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/functions.php"
+                        "function": "\\wp_die()"
                     },
                     {
-                        "function": "\\wp_dropdown_categories()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/category-template.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/category-template.php"
+                        "function": "\\wp_dropdown_categories()"
                     },
                     {
-                        "function": "\\wp_dropdown_languages()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/l10n.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/l10n.php"
+                        "function": "\\wp_dropdown_languages()"
                     },
                     {
-                        "function": "\\wp_generate_tag_cloud()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/category-template.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/category-template.php"
+                        "function": "\\wp_generate_tag_cloud()"
                     },
                     {
-                        "function": "\\wp_get_nav_menus()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/nav-menu.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/nav-menu.php"
+                        "function": "\\wp_get_nav_menus()"
                     },
                     {
-                        "function": "\\wp_get_object_terms()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\wp_get_object_terms()"
                     },
                     {
-                        "function": "\\wp_insert_post()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/post.php",
                         "param": "postarr",
-                        "file": "vendor/wordpress/wordpress/wp-includes/post.php"
+                        "function": "\\wp_insert_post()"
                     },
                     {
-                        "function": "\\wp_insert_term()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\wp_insert_term()"
                     },
                     {
-                        "function": "\\wp_insert_user()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/user.php",
                         "param": "userdata",
-                        "file": "vendor/wordpress/wordpress/wp-includes/user.php"
+                        "function": "\\wp_insert_user()"
                     },
                     {
-                        "function": "\\wp_nav_menu()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/nav-menu-template.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/nav-menu-template.php"
+                        "function": "\\wp_nav_menu()"
                     },
                     {
-                        "function": "\\wp_remote_get()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_remote_get()"
                     },
                     {
-                        "function": "\\wp_remote_head()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_remote_head()"
                     },
                     {
-                        "function": "\\wp_remote_post()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_remote_post()"
                     },
                     {
-                        "function": "\\wp_remote_request()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_remote_request()"
                     },
                     {
-                        "function": "\\wp_safe_remote_get()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_safe_remote_get()"
                     },
                     {
-                        "function": "\\wp_safe_remote_head()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_safe_remote_head()"
                     },
                     {
-                        "function": "\\wp_safe_remote_post()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_safe_remote_post()"
                     },
                     {
-                        "function": "\\wp_safe_remote_request()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/http.php"
+                        "function": "\\wp_safe_remote_request()"
                     },
                     {
-                        "function": "\\wp_update_post()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/post.php",
                         "param": "postarr",
-                        "file": "vendor/wordpress/wordpress/wp-includes/post.php"
+                        "function": "\\wp_update_post()"
                     },
                     {
-                        "function": "\\wp_update_term()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/taxonomy.php"
+                        "function": "\\wp_update_term()"
                     },
                     {
-                        "function": "\\wp_update_user()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/user.php",
                         "param": "userdata",
-                        "file": "vendor/wordpress/wordpress/wp-includes/user.php"
+                        "function": "\\wp_update_user()"
                     },
                     {
-                        "method": "\\WP_Block_Type::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-block-type.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-block-type.php"
+                        "method": "\\WP_Block_Type::__construct()"
                     },
                     {
-                        "method": "\\WP_Comment_Query::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-comment-query.php",
                         "param": "query",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-comment-query.php"
+                        "method": "\\WP_Comment_Query::__construct()"
                     },
                     {
-                        "method": "\\WP_Customize_Control::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-control.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-control.php"
+                        "method": "\\WP_Customize_Control::__construct()"
                     },
                     {
-                        "method": "\\WP_Customize_Manager::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-manager.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-manager.php"
+                        "method": "\\WP_Customize_Manager::__construct()"
                     },
                     {
-                        "method": "\\WP_Customize_Panel::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-panel.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-panel.php"
+                        "method": "\\WP_Customize_Panel::__construct()"
                     },
                     {
-                        "method": "\\WP_Customize_Section::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-section.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-section.php"
+                        "method": "\\WP_Customize_Section::__construct()"
                     },
                     {
-                        "method": "\\WP_Customize_Setting::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-setting.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-customize-setting.php"
+                        "method": "\\WP_Customize_Setting::__construct()"
                     },
                     {
-                        "method": "\\WP_Http::request()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-http.php",
                         "param": "args",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-http.php"
+                        "method": "\\WP_Http::request()"
                     },
                     {
-                        "method": "\\WP_Query::parse_query()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-query.php",
                         "param": "query",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-query.php"
+                        "method": "\\WP_Query::parse_query()"
                     },
                     {
-                        "method": "\\WP_Term_Query::__construct()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-term-query.php",
                         "param": "query",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-term-query.php"
+                        "method": "\\WP_Term_Query::__construct()"
                     },
                     {
-                        "method": "\\WP_User_Query::prepare_query()",
+                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-user-query.php",
                         "param": "query",
-                        "file": "vendor/wordpress/wordpress/wp-includes/class-wp-user-query.php"
+                        "method": "\\WP_User_Query::prepare_query()"
                     }
                 ],
                 "wordpress-install-dir": "vendor/wordpress/wordpress"
@@ -1984,7 +1984,7 @@
             "description": "I don't want to get into an argument about this.",
             "support": {
                 "issues": "https://github.com/johnbillion/args/issues",
-                "source": "https://github.com/johnbillion/args/tree/2.2.0"
+                "source": "https://github.com/johnbillion/args/tree/2.2.1"
             },
             "funding": [
                 {
@@ -1992,20 +1992,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-14T13:38:35+00:00"
+            "time": "2024-11-30T23:22:24+00:00"
         },
         {
             "name": "johnbillion/extended-cpts",
-            "version": "5.0.10",
+            "version": "5.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/extended-cpts.git",
-                "reference": "9a4bdc9d25a649376376ae46af4c830686f136d0"
+                "reference": "57f2e74155a12e7a37d07250e6739dbab5a732b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/extended-cpts/zipball/9a4bdc9d25a649376376ae46af4c830686f136d0",
-                "reference": "9a4bdc9d25a649376376ae46af4c830686f136d0",
+                "url": "https://api.github.com/repos/johnbillion/extended-cpts/zipball/57f2e74155a12e7a37d07250e6739dbab5a732b3",
+                "reference": "57f2e74155a12e7a37d07250e6739dbab5a732b3",
                 "shasum": ""
             },
             "require": {
@@ -2017,14 +2017,14 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "johnbillion/falsey-assertequals-detector": "*",
                 "johnbillion/plugin-infrastructure": "dev-trunk",
-                "johnbillion/wp-compat": "0.3.0",
-                "lucatume/wp-browser": ">=3.0.21 <3.5",
-                "phpcompatibility/phpcompatibility-wp": "^2",
-                "phpstan/phpstan": "1.12.2",
-                "phpstan/phpstan-phpunit": "1.4.0",
-                "roots/wordpress-core-installer": "^1.0.0",
+                "johnbillion/wp-compat": "0.3.1",
+                "lucatume/wp-browser": "3.2.3",
+                "phpcompatibility/phpcompatibility-wp": "2.1.5",
+                "phpstan/phpstan": "1.12.12",
+                "phpstan/phpstan-phpunit": "1.4.1",
+                "roots/wordpress-core-installer": "1.100.0",
                 "roots/wordpress-full": "*",
-                "szepeviktor/phpstan-wordpress": "1.1.6",
+                "szepeviktor/phpstan-wordpress": "1.3.5",
                 "wp-coding-standards/wpcs": "2.3.0"
             },
             "type": "library",
@@ -2054,15 +2054,9 @@
             "homepage": "https://github.com/johnbillion/extended-cpts/",
             "support": {
                 "issues": "https://github.com/johnbillion/extended-cpts/issues",
-                "source": "https://github.com/johnbillion/extended-cpts/tree/5.0.10"
+                "source": "https://github.com/johnbillion/extended-cpts/tree/5.0.11"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/johnbillion",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-11-14T14:59:43+00:00"
+            "time": "2024-11-30T23:16:17+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -3564,16 +3558,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
                 "shasum": ""
             },
             "require": {
@@ -3611,7 +3605,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -3627,20 +3621,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.1.6",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c835867b3c62bb05c7fe3d637c871c7ae52024d4"
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c835867b3c62bb05c7fe3d637c871c7ae52024d4",
-                "reference": "c835867b3c62bb05c7fe3d637c871c7ae52024d4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
                 "shasum": ""
             },
             "require": {
@@ -3677,7 +3671,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.1.6"
+                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -3693,7 +3687,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:11:02+00:00"
+            "time": "2024-10-25T15:15:23+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4310,16 +4304,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.1.8",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "42783370fda6e538771f7c7a36e9fa2ee3a84892"
+                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/42783370fda6e538771f7c7a36e9fa2ee3a84892",
-                "reference": "42783370fda6e538771f7c7a36e9fa2ee3a84892",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
+                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
                 "shasum": ""
             },
             "require": {
@@ -4351,7 +4345,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.1.8"
+                "source": "https://github.com/symfony/process/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -4367,20 +4361,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:23:19+00:00"
+            "time": "2024-11-06T14:24:19+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
-                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
                 "shasum": ""
             },
             "require": {
@@ -4434,7 +4428,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -4450,7 +4444,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/string",
@@ -5660,9 +5654,6 @@
             },
             "type": "wp-cli-package",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "2.x-dev"
-                },
                 "bundled": true,
                 "commands": [
                     "i18n",
@@ -5671,7 +5662,10 @@
                     "i18n make-mo",
                     "i18n make-php",
                     "i18n update-po"
-                ]
+                ],
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
             },
             "autoload": {
                 "files": [
@@ -6828,6 +6822,24 @@
                 "source": "https://github.com/wp-cli/wp-config-transformer/tree/v1.4.1"
             },
             "time": "2024-10-16T12:50:47+00:00"
+        },
+        {
+            "name": "wpackagist-plugin/debug-bar",
+            "version": "1.1.6",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/debug-bar/",
+                "reference": "tags/1.1.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/debug-bar.1.1.6.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/debug-bar/"
         },
         {
             "name": "wpackagist-plugin/disable-emojis",
@@ -8207,16 +8219,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v11.33.2",
+            "version": "v11.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "a01a9d0799700bf34ab3797988fdd5f420d42bfe"
+                "reference": "fd2103ddc121449a7926fc34a9d220e5b88183c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/a01a9d0799700bf34ab3797988fdd5f420d42bfe",
-                "reference": "a01a9d0799700bf34ab3797988fdd5f420d42bfe",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/fd2103ddc121449a7926fc34a9d220e5b88183c1",
+                "reference": "fd2103ddc121449a7926fc34a9d220e5b88183c1",
                 "shasum": ""
             },
             "require": {
@@ -8258,20 +8270,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-11-15T15:43:48+00:00"
+            "time": "2024-11-27T14:51:56+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v11.33.2",
+            "version": "v11.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
-                "reference": "362dd761b9920367bca1427a902158225e9e3a23"
+                "reference": "911df1bda950a3b799cf80671764e34eede131c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/362dd761b9920367bca1427a902158225e9e3a23",
-                "reference": "362dd761b9920367bca1427a902158225e9e3a23",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/911df1bda950a3b799cf80671764e34eede131c6",
+                "reference": "911df1bda950a3b799cf80671764e34eede131c6",
                 "shasum": ""
             },
             "require": {
@@ -8304,20 +8316,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-06-28T20:10:30+00:00"
+            "time": "2024-11-21T16:28:56+00:00"
         },
         {
             "name": "illuminate/contracts",
-            "version": "v11.33.2",
+            "version": "v11.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "44c15aec6ea0d997e0885aa5b04876fe8a141433"
+                "reference": "184317f701ba20ca265e36808ed54b75b115972d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/44c15aec6ea0d997e0885aa5b04876fe8a141433",
-                "reference": "44c15aec6ea0d997e0885aa5b04876fe8a141433",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/184317f701ba20ca265e36808ed54b75b115972d",
+                "reference": "184317f701ba20ca265e36808ed54b75b115972d",
                 "shasum": ""
             },
             "require": {
@@ -8352,11 +8364,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-11-15T15:40:33+00:00"
+            "time": "2024-11-25T15:33:38+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v11.33.2",
+            "version": "v11.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -8402,16 +8414,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v11.33.2",
+            "version": "v11.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "3e248061e77b67cdf868411e68cf17de524e3d1d"
+                "reference": "2b718a86571baed50fdc5d5748a846c2e58e07eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/3e248061e77b67cdf868411e68cf17de524e3d1d",
-                "reference": "3e248061e77b67cdf868411e68cf17de524e3d1d",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/2b718a86571baed50fdc5d5748a846c2e58e07eb",
+                "reference": "2b718a86571baed50fdc5d5748a846c2e58e07eb",
                 "shasum": ""
             },
             "require": {
@@ -8423,9 +8435,9 @@
                 "illuminate/conditionable": "^11.0",
                 "illuminate/contracts": "^11.0",
                 "illuminate/macroable": "^11.0",
-                "nesbot/carbon": "^2.72.2|^3.0",
+                "nesbot/carbon": "^2.72.2|^3.4",
                 "php": "^8.2",
-                "voku/portable-ascii": "^2.0"
+                "voku/portable-ascii": "^2.0.2"
             },
             "conflict": {
                 "tightenco/collect": "<5.5.33"
@@ -8441,7 +8453,7 @@
                 "symfony/process": "Required to use the composer class (^7.0).",
                 "symfony/uid": "Required to use Str::ulid() (^7.0).",
                 "symfony/var-dumper": "Required to use the dd function (^7.0).",
-                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1)."
+                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.6.1)."
             },
             "type": "library",
             "extra": {
@@ -8474,7 +8486,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-11-19T19:46:19+00:00"
+            "time": "2024-11-27T14:58:17+00:00"
         },
         {
             "name": "lucatume/wp-browser",
@@ -8660,12 +8672,12 @@
             "type": "laravel-package",
             "extra": {
                 "laravel": {
-                    "providers": [
-                        "MikeMcLin\\WpPassword\\WpPasswordProvider"
-                    ],
                     "aliases": {
                         "WpPassword": "MikeMcLin\\WpPassword\\Facades\\WpPassword"
-                    }
+                    },
+                    "providers": [
+                        "MikeMcLin\\WpPassword\\WpPasswordProvider"
+                    ]
                 }
             },
             "autoload": {
@@ -9141,16 +9153,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.6.2",
+            "version": "v6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f50fd7ed45894d036e4fef9ab7e5bbbaff6a30cc"
+                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f50fd7ed45894d036e4fef9ab7e5bbbaff6a30cc",
-                "reference": "f50fd7ed45894d036e4fef9ab7e5bbbaff6a30cc",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
+                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
                 "shasum": ""
             },
             "require-dev": {
@@ -9159,9 +9171,9 @@
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.4.1",
-                "phpstan/phpstan": "^1.10.49",
+                "phpstan/phpstan": "^1.11",
                 "phpunit/phpunit": "^9.5",
-                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
             "suggest": {
@@ -9183,22 +9195,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.6.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.7.1"
             },
-            "time": "2024-09-30T07:10:48+00:00"
+            "time": "2024-11-24T03:57:09+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",
-            "version": "v6.6.2",
+            "version": "v6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-tests-stubs.git",
-                "reference": "4878404d72cd92dfd6c5143ca3f1758575c50bee"
+                "reference": "37cc3f2136034cc239149151933e1c5be6ce6103"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/4878404d72cd92dfd6c5143ca3f1758575c50bee",
-                "reference": "4878404d72cd92dfd6c5143ca3f1758575c50bee",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/37cc3f2136034cc239149151933e1c5be6ce6103",
+                "reference": "37cc3f2136034cc239149151933e1c5be6ce6103",
                 "shasum": ""
             },
             "require-dev": {
@@ -9223,9 +9235,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-tests-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.6.2"
+                "source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.7.1"
             },
-            "time": "2024-10-18T12:17:46+00:00"
+            "time": "2024-11-23T22:07:27+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -9760,16 +9772,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.11",
+            "version": "1.12.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0d1fc20a962a91be578bcfe7cf939e6e1a2ff733"
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0d1fc20a962a91be578bcfe7cf939e6e1a2ff733",
-                "reference": "0d1fc20a962a91be578bcfe7cf939e6e1a2ff733",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
                 "shasum": ""
             },
             "require": {
@@ -9814,7 +9826,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-17T14:08:01+00:00"
+            "time": "2024-11-28T22:13:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -11352,16 +11364,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.19",
+            "version": "v2.11.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1"
+                "reference": "eb2b351927098c24860daa7484e290d3eed693be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
-                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/eb2b351927098c24860daa7484e290d3eed693be",
+                "reference": "eb2b351927098c24860daa7484e290d3eed693be",
                 "shasum": ""
             },
             "require": {
@@ -11372,9 +11384,9 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
                 "sirbrillig/phpcs-import-detection": "^1.1",
-                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -11406,7 +11418,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2024-06-26T20:08:34+00:00"
+            "time": "2024-12-02T16:37:49+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -11627,16 +11639,16 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v7.1.6",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "97bebc53548684c17ed696bc8af016880f0f098d"
+                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/97bebc53548684c17ed696bc8af016880f0f098d",
-                "reference": "97bebc53548684c17ed696bc8af016880f0f098d",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
+                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
                 "shasum": ""
             },
             "require": {
@@ -11681,7 +11693,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.1.6"
+                "source": "https://github.com/symfony/clock/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -11697,7 +11709,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -11767,16 +11779,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.4.45",
+            "version": "v5.4.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "89647a57db280f9f93c27271fea58babb77bb473"
+                "reference": "b57df76f4757a9a8dfbb57ba48d7780cc20776c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/89647a57db280f9f93c27271fea58babb77bb473",
-                "reference": "89647a57db280f9f93c27271fea58babb77bb473",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/b57df76f4757a9a8dfbb57ba48d7780cc20776c6",
+                "reference": "b57df76f4757a9a8dfbb57ba48d7780cc20776c6",
                 "shasum": ""
             },
             "require": {
@@ -11822,7 +11834,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.45"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.48"
             },
             "funding": [
                 {
@@ -11838,7 +11850,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-22T13:05:35+00:00"
+            "time": "2024-11-13T14:36:38+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -11927,16 +11939,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "8f93aec25d41b72493c6ddff14e916177c9efc50"
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/8f93aec25d41b72493c6ddff14e916177c9efc50",
-                "reference": "8f93aec25d41b72493c6ddff14e916177c9efc50",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
                 "shasum": ""
             },
             "require": {
@@ -11983,7 +11995,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -11999,7 +12011,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
@@ -12174,16 +12186,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a"
+                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
-                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/4667ff3bd513750603a09c8dedbea942487fb07c",
+                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c",
                 "shasum": ""
             },
             "require": {
@@ -12232,7 +12244,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -12248,7 +12260,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -12632,24 +12644,6 @@
             "time": "2024-03-25T16:39:00+00:00"
         },
         {
-            "name": "wpackagist-plugin/debug-bar",
-            "version": "1.1.6",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/debug-bar/",
-                "reference": "tags/1.1.6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/debug-bar.1.1.6.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/debug-bar/"
-        },
-        {
             "name": "zordius/lightncandy",
             "version": "v1.2.6",
             "source": {
@@ -12714,7 +12708,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-exif": "*",
         "ext-gd": "*",
         "ext-intl": "*",
@@ -12722,7 +12716,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e416790551b56eef7270c3771f5e0313",
+    "content-hash": "5697d4fec79deffd449517efc49edf4c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6954,24 +6954,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/user-switching/"
-        },
-        {
-            "name": "wpackagist-plugin/wp-tota11y",
-            "version": "1.2.0",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/wp-tota11y/",
-                "reference": "tags/1.2.0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-tota11y.1.2.0.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/wp-tota11y/"
         },
         {
             "name": "wpengine/advanced-custom-fields-pro",

--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -49,7 +49,6 @@ final class ForcePluginActivation {
 		'debug-bar/debug-bar.php'                                           => [ 'local', 'development' ],
 		'limit-login-attempts-reloaded/limit-login-attempts-reloaded.php'   => [ 'development', 'staging', 'production' ],
 		'tribe-glomar/tribe-glomar.php'                                     => [ 'development', 'staging' ],
-		'wp-tota11y/wp-tota11y.php'                                         => [ 'local', 'development', 'staging' ],
 	];
 
 	/**
@@ -64,7 +63,6 @@ final class ForcePluginActivation {
 	private array $networkOnlyPlugins = [
 		'advanced-custom-fields-pro/acf.php' => [ 'all' ],
 		'debug-bar/debug-bar.php'            => [ 'local', 'development' ],
-		'wp-tota11y/wp-tota11y.php'          => [ 'local', 'development', 'staging' ],
 	];
 
 	/**


### PR DESCRIPTION
## What does this do/fix?
- Updates Lando PHP version to 8.3
- Updates Lando database container to MariaDB 10.11 as the default, 10.3 is no longer a supported version. *NOTE:* This is a breaking change. Existing local dev environments should do a `lando db-export` before pulling this change.
- Disables Mailhog containers by default as they cause an error on lando start. See the code for more info.
- Removes the WP Tota11y plugin as a composer dep since it's not used.
- Moves WP Debug plugin to a regular composer require so it's available in Dokku envs (I could be persuaded to remove this entirely)
- Bumps the PHP version in composer.json to 8.3.

Links to relevant issues
- [MOOSE-171](https://moderntribe.atlassian.net/browse/MOOSE-171)

[MOOSE-171]: https://moderntribe.atlassian.net/browse/MOOSE-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ