### PR TITLE
[MOOSE-153]: lint only core theme package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"lint:js:fix": "wp-scripts lint-js \"$npm_package_config_coreThemeDir/**/*.js\" --fix",
 		"lint:configs": "wp-scripts lint-js \"./*.js\"",
 		"lint:configs:fix": "wp-scripts lint-js \"./*.js\" --fix",
-		"lint:pkg-json": "wp-scripts lint-pkg-json",
+		"lint:pkg-json": "wp-scripts lint-pkg-json \"./package.json\"",
 		"create-block": "cd \"$npm_package_config_coreThemeBlocksDir/tribe\" && npx @wordpress/create-block --no-plugin --namespace tribe --template $npm_package_config_coreBlockTemplatesDir",
 		"packages-update": "wp-scripts packages-update",
 		"check-engines": "wp-scripts check-engines",


### PR DESCRIPTION
## What does this do/fix?

- migrates an update from learn.tri.be that fixed an issue where the `package.json` linting script could try to lint other `package.json` files that were checked into the repo. The script should now _only_ check the `package.json` file that we define in the core theme. 

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-153)

Screenshots/video:
- Confirming script is working on correct `package.json` file: http://p.tri.be/i/aw6VIN
