### PR TITLE
[MOOSE-181] Table Overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 ## [2025.01]
+- Add ability for table blocks to utilize the `overflow-x` set on them by setting a `min-width` property for the `table` element within the table block.
 - Enabled background images on the Group block; We should try to use this instead of the Cover block where possible.
 
 ## [2024.08]

--- a/wp-content/themes/core/assets/pcss/layout/_variables.pcss
+++ b/wp-content/themes/core/assets/pcss/layout/_variables.pcss
@@ -7,6 +7,7 @@
 :root {
 	--grid-margin: var(--wp--custom--spacing--grid-margin);
 	--grid-gutter: var(--wp--custom--spacing--grid-gutter);
+	--grid-content-width: var(--wp--style--global--content-size);
 	--grid-wide-width: var(--wp--style--global--wide-size);
 
 	/* this should match the "Grid" size defined in the

--- a/wp-content/themes/core/blocks/core/table/style.pcss
+++ b/wp-content/themes/core/blocks/core/table/style.pcss
@@ -9,6 +9,15 @@
 	   that wraps the table element */
 	margin-bottom: 0;
 
+	/* overflow-x is already set on table elements by default in WP
+	   so we don't need to set it here, but we do need to prevent
+	   tables from being able to reduce their width so that the
+	   overlfow actually applies on tables with minimal content.
+	   This can be updated as needed per project. */
+	table {
+		min-width: var(--grid-content-width);
+	}
+
 	& th {
 		border-top: 0;
 		padding-top: 0;


### PR DESCRIPTION
## What does this do/fix?

- adds content width as a layout variable
- sets `min-width` on table elements within Table blocks. As the comment states, this is the only way to actually apply the `overflow-x` set on the Table block for tables that have minimal content. 
- I'll put this one through DQA so designers can confirm what minimum width they'd like to see.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-181)

Screenshots/video:
- Mobile table view: http://p.tri.be/i/AzzZSr
