### PR TITLE
Lando Project Setup Improvements and Node integration

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -33,6 +33,11 @@ services:
 #      - appserver_nginx
 #      - appserver
 
+events:
+  post-start:
+    - appserver: composer install
+    - node: npm install && npm run build
+
 tooling:
   xdebug-on:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,5 +1,6 @@
 name: moose
 recipe: wordpress
+
 config:
   php: '8.3'
   database: mariadb:11.5
@@ -7,11 +8,11 @@ config:
   via: nginx
   xdebug: false
   memcached: true
+
 services:
   appserver:
-    run:
-      - composer install
-      - composer run copy-local-configs
+    build:
+      - composer create-local-configs
     overrides:
       environment:
         - XDEBUG_TRIGGER=1

--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,8 @@ services:
     overrides:
       environment:
         - XDEBUG_TRIGGER=1
+  node:
+    type: node:22
 
 # Enabling MailHog will cause an error on start: `/bin/sh: 1: curl: not found`.
 # Related GH Issue: https://github.com/lando/mailhog/issues/35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ Each changelog entry should be prefixed with the category of the item (Added, Ch
 Security).
 
 ## [2025.01]
-
+- Added: Node service to Lando so FE assets can be build automatically on start up.
+- Updated: project start up scripts to automatically generate the correct contents of the lcoal config files.
+- Updated: script to install WordPress so we can use a version constant and not install WP every time composer is
+  installed or updated.
 - Added: ability for table blocks to utilize the `overflow-x` set on them by setting a `min-width` property for the
   `table` element within the table block.
 - Updated: Enabled background images on the Group block; We should try to use this instead of the Cover block where

--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ maintained by the folks at [Modern Tribe](https://tri.be).
    [1Password CLI](#1password-cli). See the [Composer Docs](./docs/composer.md#creating-an-authjson-file) for manual
    instructions.)
 3. Run `lando start` to create the local environment.
-4. Run `nvm use` to ensure the correct version of node is in use.
-5. Run `npm install` to install the required npm dependencies.
-6. Run `npm run dist` to build the theme assets.
 
-That should be it! After Lando starts the first time, it should automatically trigger a composer install and create the
-necessary local config files for the project.
+That should be it! After Lando starts the first time, it will automatically create the necessary local config files for
+the project. Additionally, Each time Lando starts, it will automatically run:
+* `composer install` to install the latest composer dependencies.
+* `npm install && npm run build` to install the latest npm dependencies and build the frontend assets.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ maintained by the folks at [Modern Tribe](https://tri.be).
 * [Git](https://git-scm.com/)
 * [Composer](https://getcomposer.org/)
 * [Node & NPM](https://nodejs.org/)
-    * [NVM](https://github.com/nvm-sh/nvm) is recommended for managing multiple versions of node on the same workstation.
+    * [NVM](https://github.com/nvm-sh/nvm) is recommended for managing multiple versions of node on the same
+      workstation.
 * [Lando](https://lando.dev/) (Optional) Provides a consistent local development environment for all team members.
 * [1Password CLI](https://developer.1password.com/docs/cli/) (Optional) Automates the creation of composer's `auth.json`
   file so that paid 3rd-party plugins like Advanced Custom Fields Pro and Gravity Forms can be installed via composer.
@@ -30,9 +31,9 @@ maintained by the folks at [Modern Tribe](https://tri.be).
 3. Run `lando start` to create the local environment.
 
 That should be it! After Lando starts the first time, it will automatically create the necessary local config files for
-the project. Additionally, Each time Lando starts, it will automatically run:
-* `composer install` to install the latest composer dependencies.
-* `npm install && npm run build` to install the latest npm dependencies and build the frontend assets.
+the project. Additionally, each time Lando starts it will automatically run `composer install` and
+`npm install && npm run build` make sure all the project dependencies are installed and the theme assets have been
+built.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ members to use and provides a number of helpful features. Below are a number of 
 * `lando destroy` - Destroys the local development environment. *WARNING:* This is a destructive action and will delete
   the existing data within the project database and completely remove all the project containers. It will not delete the
   project files on your local machine.
+* `lando xdebug-on` - Enables Xdebug in the project container (xDebug is disabled by default).
+* `lando xdebug-off` - Disables Xdebug in the project container (xDebug is disabled by default).
 
 For further documentation on Lando, please visit the [Lando Docs](https://docs.lando.dev/).
 

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,7 @@
 	"prefer-stable": true,
 	"scripts": {
 		"create-auth": "op inject -i auth.template.json -o auth.json",
-		"copy-local-configs": [
-			"@php -r \"file_exists('local-config.php') || copy('local-config-sample.php', 'local-config.php');\"",
-			"@php -r \"file_exists('local-config.json') || copy('local-config-sample.json', 'local-config.json');\""
-		],
+		"create-local-configs": "php ./dev/scripts/create-local-configs.php",
 		"install-wordpress": "./dev/scripts/install-wordpress.sh",
 		"phpcbf": "./vendor/bin/phpcbf -s",
 		"phpcs": "./vendor/bin/phpcs",
@@ -40,7 +37,7 @@
 	},
 	"scripts-descriptions": {
 		"create-auth": "Create or update the auth.json file for Composer via 1Password CLI.",
-		"copy-local-configs": "Copies the local-config.php and local-config.json files.",
+		"create-local-configs": "Creates local config files for the project.",
 		"install-wordpress": "Runs the WP CLI command to download and install WordPress. To change the WordPress version, run `composer config extra.wordpress-version <new-version>`.",
 		"phpcs": "Run PHPCS on the project.",
 		"phpcbf": "Run PHPCBF on the project.",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 			"@php -r \"file_exists('local-config.php') || copy('local-config-sample.php', 'local-config.php');\"",
 			"@php -r \"file_exists('local-config.json') || copy('local-config-sample.json', 'local-config.json');\""
 		],
-		"install-wordpress": "./vendor/bin/wp core download --version=6.7.1 --skip-content --force",
+		"install-wordpress": "./dev/scripts/install-wordpress.sh",
 		"phpcbf": "./vendor/bin/phpcbf -s",
 		"phpcs": "./vendor/bin/phpcs",
 		"phpstan": "./vendor/bin/phpstan analyse --memory-limit=-1",
@@ -41,7 +41,7 @@
 	"scripts-descriptions": {
 		"create-auth": "Create or update the auth.json file for Composer via 1Password CLI.",
 		"copy-local-configs": "Copies the local-config.php and local-config.json files.",
-		"install-wordpress": "Runs the wpcli command to download and install core WordPress. To change the WordPress version, update the --version value.",
+		"install-wordpress": "Runs the WP CLI command to download and install WordPress. To change the WordPress version, run `composer config extra.wordpress-version <new-version>`.",
 		"phpcs": "Run PHPCS on the project.",
 		"phpcbf": "Run PHPCBF on the project.",
 		"phpstan": "Run PHPStan on the project.",
@@ -123,6 +123,7 @@
 		"wpengine/advanced-custom-fields-pro": "6.3.11"
 	},
 	"extra": {
+		"wordpress-version": "6.7.1",
 		"installer-paths": {
 			"wp-content/plugins/{$name}": [
 				"type:wordpress-plugin"

--- a/dev/scripts/create-local-configs.php
+++ b/dev/scripts/create-local-configs.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/**
+ * Copies the local-config-sample.php file to local-config.php if it doesn't exist.
+ * Generates a local-config.json file using Lando's own environment variables if it doesn't exist.
+ */
+
+/**
+ * PHP Local Config
+ */
+
+if ( file_exists( 'local-config.php' ) ) {
+	echo "local-config.php already exists. Skipping.\n";
+} else {
+	copy('local-config-sample.php', 'local-config.php');
+}
+
+/**
+ * JSON Local Config
+ */
+
+if ( ! getenv( 'LANDO_INFO' ) ) {
+	echo "To create a local-config.json file, this script must be run within a Lando container.\n";
+	echo "Try `lando composer create-local-configs` if you're using Lando or manually create the file using local-config-sample.json as an example.\n";
+	exit;
+}
+
+if ( file_exists( 'local-config.json' ) ) {
+	echo "local-config.json already exists. Skipping.\n";
+	exit;
+}
+
+$lando_info = json_decode( getenv( 'LANDO_INFO' ) );
+
+// Get the HTTP server details, depending on the project configuration
+$http_service_info = $lando_info->appserver->via === 'apache' ? $lando_info->appserver : $lando_info->appserver_nginx;
+
+// Get the cert directory by removing the root `/lando` directory from Lando's internal cert path
+$cert_directory = str_replace( '/lando', '', dirname( getenv( 'LANDO_SERVICE_CERT' ) ) );
+
+// Create the config array
+$config = [
+	// Append Lando's cert directory to Lando's local config directory path
+	'certPath' => getenv( 'LANDO_CONFIG_DIR' ) . $cert_directory,
+	// Set the cert name to the base name of Lando's nginx cert path without the `.internal` extension
+	'certName' => basename( $http_service_info->hostnames[0], '.internal' ),
+	// Set the host from Lando's appserver_nginx service URL
+	'host'     => parse_url( $http_service_info->urls[0] )['host'],
+	'protocol' => 'https'
+];
+
+// Write the config values to local-config.json
+file_put_contents( 'local-config.json', json_encode( $config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+
+exit;

--- a/dev/scripts/create-local-configs.php
+++ b/dev/scripts/create-local-configs.php
@@ -41,9 +41,9 @@ $cert_directory = str_replace( '/lando', '', dirname( getenv( 'LANDO_SERVICE_CER
 $config = [
 	// Append Lando's cert directory to Lando's local config directory path
 	'certPath' => getenv( 'LANDO_CONFIG_DIR' ) . $cert_directory,
-	// Set the cert name to the base name of Lando's nginx cert path without the `.internal` extension
+	// Set the cert name to the base name of Lando's hostname without the `.internal` extension
 	'certName' => basename( $http_service_info->hostnames[0], '.internal' ),
-	// Set the host from Lando's appserver_nginx service URL
+	// Set the host from Lando's service URL
 	'host'     => parse_url( $http_service_info->urls[0] )['host'],
 	'protocol' => 'https'
 ];

--- a/dev/scripts/install-wordpress.sh
+++ b/dev/scripts/install-wordpress.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Simple bash script to check the current version of WordPress and update it if necessary.
+
+CURRENT_VERSION=$(wp core version)
+REQUESTED_VERSION=$(composer config extra.wordpress-version)
+
+if [ "$CURRENT_VERSION" == "$REQUESTED_VERSION" ]; then
+  echo "WordPress is already at version $REQUESTED_VERSION. Skipping install."
+  exit 0
+fi
+
+echo "Updating WordPress to version $REQUESTED_VERSION..."
+wp core download --version=$REQUESTED_VERSION --skip-content --force
+exit 0;

--- a/docs/composer.md
+++ b/docs/composer.md
@@ -25,7 +25,7 @@ day-to-day PHP development.
 
 ## Updating WordPress
 
-To adjust the installed version of WordPress, change the `--version=` value in the `install-wordpress` composer script.
+To adjust the installed version of WordPress, run `composer config extra.wordpress-version <new-version>` and then `composer install-wordpress`.
 
 ## Adding a Paid or Premium WordPress Plugin
 

--- a/docs/composer.md
+++ b/docs/composer.md
@@ -13,8 +13,8 @@ day-to-day PHP development.
 
 * `composer create-auth` - Create or update the auth.json file for Composer via 1Password CLI. (Cannot be run within a
   Lando container.)
-* `composer copy-local-configs` - Creates the `local-config.php` and `local-config.json` files from the respective
-  sample file.
+* `composer create-local-configs` - Creates the `local-config.php` and `local-config.json` files as needed for the 
+  project.
 * `composer install-wordpress` - Runs the WP CLI command to download and install WordPress core. To change the WordPress
   version, update the `--version` value for this script.
 * `composer phpcs` - Run PHPCS on the project.

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,26 +1,31 @@
 # NPM Packages, Scripts & Building Assets
 
 NPM is used to manage frontend dependencies. There are also a number of npm scripts defined to assist in day-to-day
-development. These npm scripts are based on WordPress's [WP-Scripts](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/) package. See the documentation there for 
-further details.
+development. These npm scripts are based on
+WordPress's [WP-Scripts](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/)
+package. See the documentation there for further details.
 
 ## Building Assets
 
-To build the theme assets for your local development environment, the following steps are sufficient:
+If you are not working with the theme assets locally, and you are using Lando, you can skip this section. Lando will
+automatically build the assets for you each time the project is started. To manually build the theme assets for your
+local development environment, use the following steps:
 
 1. In the root of the project, run `nvm use` to confirm the correct version of node is in-use.
 1. Run `npm install` to install the required dependencies.
-1. Run `npm run dist` to build the production assets
+1. Run `npm run build` to build the non-production assets.
 
 ## Using Browsersync for Local Dev
 
-To handle live-reload for changes, this project utilizes Browsersync to watch for asset file changes and reload the 
-browser. In addition, Browsersync can be configured via a `local-config.json` file to proxy your local environment's 
-SSL configuration to allow live-reloading from a specific local project URL rather than localhost. To use Browsersync
-for local development follow the steps below:
+To handle live-reload for changes, this project utilizes Browsersync to watch for asset file changes and reload the
+browser. In addition, Browsersync can be configured via a `local-config.json` file to proxy your local environment's
+SSL configuration to allow live-reloading from a specific local project URL rather than localhost.
+
+Lando will automatically generate an proper local-config.json file the first time a project is started. If you are not
+using Lando, you'll need to manually create this file using the steps below:
 
 1. Duplicate the `local-config-sample.json` file into a git-ignored `local-config.json` and update the `certsPath`,
-`certName` and `host` values to match your local dev set up. Examples are provided for Lando and LocalWP.
+   `certName` and `host` values to match your local dev set up. Examples are provided for Lando and LocalWP.
 1. In the root of the project, run `nvm use` to confirm the correct version of node is in-use.
 1. Run `npm install` to install the required dependencies.
 1. Run `npm run dev` to start the webpack watch & browsersync tasks.
@@ -33,7 +38,8 @@ for local development follow the steps below:
 * `npm run format` - Runs Prettier on all theme assets (css, scss, js, & json files).
 * `npm run lint` - Prettifies, lints (and fixes) theme & root assets (css, scss, js, & json files).
 * `npm run create-block` - Starts an interactive shell script to generate a new block per WordPress's
-  [Create Block script](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) and the theme config.
+  [Create Block script](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/)
+  and the theme config.
 
 Several scripts have sub-tasks that can be run individually. Reference `package.json` for details.
 Additionally, there are several scripts aliased directly from wp-scripts that may be useful:


### PR DESCRIPTION
## What does this do/fix?

* Adds a bash script for managing the installed version of WordPress via Composer. This make it simpler to manage the WP version constant and prevents the CLI download/install command from running unless the version of WP has changed in composer.json.
* Add a PHP script to automatically generate both local-config files (PHP & JSON) and properly populate local-config.json with values from Lando's project configuration.
* Adds a Node service to the Lando config so that the npm packages can be automatically installed and the theme assets automatically built each time the Lando project starts. Note that this isn't intended to prevent using `nvm`, installing the nom packages locally or running the npm scripts locally for frontend development. It's only intended to ease onboarding to a new project for developers who don't need to worry about regularly installing the npm packages or building the assets.  
* Misc documentation updated for the changes above.
