### PR TITLE
[MOOSE-172] Admin Menu Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 ## [2025.01]
 
+- Added: `Admin_Menu_Order` class to handle reordering the WP Admin menu items that Moose loads with by default.
+  This also includes Yoast SEO & RankMath, just in case either are used by default. 
 - Added: Node service to Lando so FE assets can be built automatically on start up.
 - Updated: project start up scripts to automatically generate the correct contents of the lcoal config files.
 - Updated: script to install WordPress so we can use a version constant and not install WP every time composer is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 - Updated: project start up scripts to automatically generate the correct contents of the lcoal config files.
 - Updated: script to install WordPress so we can use a version constant and not install WP every time composer is
   installed or updated.
-- Updated: ESLint config now supports browser environment variable such as `IntersectionObserver`
+- Updated: ESLint config now supports browser environment variables such as `IntersectionObserver`
 - Added: ability for table blocks to utilize the `overflow-x` set on them by setting a `min-width` property for the
   `table` element within the table block.
 - Updated: Enabled background images on the Group block; We should try to use this instead of the Cover block where

--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -29,6 +29,7 @@ class Core {
 		Integrations\Integrations_Subscriber::class,
 		Object_Meta\Meta_Subscriber::class,
 		Theme_Config\Theme_Config_Subscriber::class,
+		Menus\Menu_Subscriber::class,
 
 		// Post Types
 		Post_Types\Page\Page_Subscriber::class,

--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -23,13 +23,13 @@ class Core {
 	 * @var string[] Names of classes extending Abstract_Subscriber.
 	 */
 	private array $subscribers = [
-		Settings\Settings_Subscriber::class,
 		Assets\Assets_Subscriber::class,
 		Blocks\Blocks_Subscriber::class,
 		Integrations\Integrations_Subscriber::class,
-		Object_Meta\Meta_Subscriber::class,
-		Theme_Config\Theme_Config_Subscriber::class,
 		Menus\Menu_Subscriber::class,
+		Object_Meta\Meta_Subscriber::class,
+		Settings\Settings_Subscriber::class,
+		Theme_Config\Theme_Config_Subscriber::class,
 
 		// Post Types
 		Post_Types\Page\Page_Subscriber::class,

--- a/wp-content/plugins/core/src/Menus/Admin_Menu_Order.php
+++ b/wp-content/plugins/core/src/Menus/Admin_Menu_Order.php
@@ -22,6 +22,7 @@ class Admin_Menu_Order {
 			'edit.php?post_type=training',
 			'separator-last',
 			'edit.php?post_type=acf-field-group',
+			'wpseo_dashboard',
 			'rank-math',
 		];
 	}

--- a/wp-content/plugins/core/src/Menus/Admin_Menu_Order.php
+++ b/wp-content/plugins/core/src/Menus/Admin_Menu_Order.php
@@ -2,19 +2,9 @@
 
 namespace Tribe\Plugin\Menus;
 
-class Menu_Order {
+class Admin_Menu_Order {
 
-	public const SITE_HAS_CUSTOM_MENU_ORDER = true;
-
-	public function site_has_custom_menu_order(): bool {
-		return self::SITE_HAS_CUSTOM_MENU_ORDER;
-	}
-
-	public function custom_menu_order( array $menu_ord ): array {
-		if ( ! $this->site_has_custom_menu_order() ) {
-			return $menu_ord;
-		}
-
+	public function custom_menu_order(): array {
 		return [
 			'index.php',
 			'separator1',

--- a/wp-content/plugins/core/src/Menus/Menu_Order.php
+++ b/wp-content/plugins/core/src/Menus/Menu_Order.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Menus;
+
+class Menu_Order {
+
+	public const SITE_HAS_CUSTOM_MENU_ORDER = true;
+
+	public function site_has_custom_menu_order(): bool {
+		return self::SITE_HAS_CUSTOM_MENU_ORDER;
+	}
+
+	public function custom_menu_order( array $menu_ord ): array {
+		if ( ! $this->site_has_custom_menu_order() ) {
+			return $menu_ord;
+		}
+
+		return [
+			'index.php',
+			'separator1',
+			'edit.php?post_type=page',
+			// place CPTs here
+			'edit.php',
+			'upload.php',
+			'gf_edit_forms',
+			'separator2',
+			'themes.php',
+			'plugins.php',
+			'users.php',
+			'tools.php',
+			'options-general.php',
+			'edit.php?post_type=training',
+			'separator-last',
+			'edit.php?post_type=acf-field-group',
+			'rank-math',
+		];
+	}
+
+}

--- a/wp-content/plugins/core/src/Menus/Menu_Subscriber.php
+++ b/wp-content/plugins/core/src/Menus/Menu_Subscriber.php
@@ -7,12 +7,10 @@ use Tribe\Plugin\Core\Abstract_Subscriber;
 class Menu_Subscriber extends Abstract_Subscriber {
 
 	public function register(): void {
-		add_filter( 'custom_menu_order', function (): bool {
-			return $this->container->get( Menu_Order::class )->site_has_custom_menu_order();
-		} );
+		add_filter( 'custom_menu_order', '__return_true' );
 
-		add_filter( 'menu_order', function ( array $menu_ord ): array {
-			return $this->container->get( Menu_Order::class )->custom_menu_order( $menu_ord );
+		add_filter( 'menu_order', function (): array {
+			return $this->container->get( Admin_Menu_Order::class )->custom_menu_order();
 		} );
 	}
 

--- a/wp-content/plugins/core/src/Menus/Menu_Subscriber.php
+++ b/wp-content/plugins/core/src/Menus/Menu_Subscriber.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Menus;
+
+use Tribe\Plugin\Core\Abstract_Subscriber;
+
+class Menu_Subscriber extends Abstract_Subscriber {
+
+	public function register(): void {
+		add_filter( 'custom_menu_order', function (): bool {
+			return $this->container->get( Menu_Order::class )->site_has_custom_menu_order();
+		} );
+
+		add_filter( 'menu_order', function ( array $menu_ord ): array {
+			return $this->container->get( Menu_Order::class )->custom_menu_order( $menu_ord );
+		} );
+	}
+
+}

--- a/wp-content/plugins/core/src/Post_Types/Training/Config.php
+++ b/wp-content/plugins/core/src/Post_Types/Training/Config.php
@@ -29,9 +29,10 @@ class Config extends Post_Type_Config {
 
 	public function get_labels(): array {
 		return [
-			'singular' => __( 'Training Doc', 'tribe' ),
-			'plural'   => __( 'Training Docs', 'tribe' ),
-			'slug'     => $this->post_type,
+			'singular'  => __( 'Training Doc', 'tribe' ),
+			'plural'    => __( 'Training Docs', 'tribe' ),
+			'menu_name' => __( 'Training', 'tribe' ),
+			'slug'      => $this->post_type,
 		];
 	}
 


### PR DESCRIPTION
## What does this do/fix?

Please note I do not know if this is the best way to go about this. The only other way I could think of would be to awkwardly handle reordering all the menu item priorities, which would get super messy IMO. 

This PR assumes that newly created CPTs would need to be manually added to the menu order array in the correct spot.

- reorder menu items via `menu_order` filter. 
- update Training Docs menu item label

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-172)

Screenshots/video:
- Updated menu order: http://p.tri.be/i/42Jcpi
