### PR TITLE
[MOOSE-179]: add details block summary link styling

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -11,6 +11,7 @@ use Tribe\Theme\bindings\Query_Results_Count;
 use Tribe\Theme\blocks\core\button\Button;
 use Tribe\Theme\blocks\core\column\Column;
 use Tribe\Theme\blocks\core\columns\Columns;
+use Tribe\Theme\blocks\core\details\Details;
 use Tribe\Theme\blocks\core\embed\Embed;
 use Tribe\Theme\blocks\core\image\Image;
 use Tribe\Theme\blocks\core\lists\Lists;
@@ -46,6 +47,7 @@ class Blocks_Definer implements Definer_Interface {
 				DI\get( Button::class ),
 				DI\get( Column::class ),
 				DI\get( Columns::class ),
+				DI\get( Details::class ),
 				DI\get( Embed::class ),
 				DI\get( Image::class ),
 				DI\get( Lists::class ),

--- a/wp-content/themes/core/blocks/core/details/Details.php
+++ b/wp-content/themes/core/blocks/core/details/Details.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Theme\blocks\core\details;
+
+use Tribe\Plugin\Blocks\Block_Base;
+
+class Details extends Block_Base {
+
+	public function get_block_name(): string {
+		return 'core/details';
+	}
+
+}

--- a/wp-content/themes/core/blocks/core/details/index.js
+++ b/wp-content/themes/core/blocks/core/details/index.js
@@ -1,0 +1,5 @@
+/**
+ * Scripts specific to this block
+ */
+
+import './style.pcss';

--- a/wp-content/themes/core/blocks/core/details/style.pcss
+++ b/wp-content/themes/core/blocks/core/details/style.pcss
@@ -1,0 +1,21 @@
+/**
+ * Styles specific to this block
+ */
+
+.wp-block-details {
+
+	/**
+	 * Summary elements shouldn't contain text markup, but for some
+	 * reason WP allows this markup within the summary text if you
+	 * copy & paste it into the summary element. We should try to
+	 * avoid this pattern, but since it's possible, we need to support
+	 * it. This only applies to links within the summary element.
+	 */
+	summary {
+
+		a {
+
+			@mixin inline-text-link;
+		}
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

- style links within Details block `summary` elements.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-179)

Screenshots/video:
- Updated link styling: http://p.tri.be/i/CRb0tb
