### PR TITLE
[MOOSE-193] Create WP Controls Script Fixes

### DIFF
--- a/wp-content/themes/core/assets/js/utils/create-wp-controls.js
+++ b/wp-content/themes/core/assets/js/utils/create-wp-controls.js
@@ -47,10 +47,12 @@ const applyBlockProps = ( props, block, attributes ) => {
 		// determine if we should add a class name to the block
 		if (
 			Object.keys( control ).includes( 'applyClass' ) &&
-			props.className &&
+			props.className !== undefined &&
 			! props.className.includes( control.applyClass ) &&
-			attributes[ control.attribute ] &&
-			attributes[ control.attribute ] !== control.defaultValue
+			attributes[ control.attribute ] !== undefined &&
+			( ( control.type === 'toggle' &&
+				attributes[ control.attribute ] ) ||
+				control.type !== 'toggle' )
 		) {
 			props.className = `${ props.className } ${ control.applyClass }`;
 		}
@@ -59,8 +61,10 @@ const applyBlockProps = ( props, block, attributes ) => {
 		// assumes we only have one style property to add and assigns it to the value of the control created
 		if (
 			Object.keys( control ).includes( 'applyStyleProperty' ) &&
-			attributes[ control.attribute ] &&
-			attributes[ control.attribute ] !== control.defaultValue
+			attributes[ control.attribute ] !== undefined &&
+			( ( control.type === 'toggle' &&
+				attributes[ control.attribute ] ) ||
+				control.type !== 'toggle' )
 		) {
 			props.style = {
 				...props.style,
@@ -96,8 +100,10 @@ const applyEditorBlockProps = createHigherOrderComponent(
 				if (
 					Object.keys( control ).includes( 'applyClass' ) &&
 					! classes.includes( control.applyClass ) &&
-					attributes[ control.attribute ] &&
-					attributes[ control.attribute ] !== control.defaultValue
+					attributes[ control.attribute ] !== undefined &&
+					( ( control.type === 'toggle' &&
+						attributes[ control.attribute ] ) ||
+						control.type !== 'toggle' )
 				) {
 					classes.push( control.applyClass );
 				}
@@ -105,8 +111,10 @@ const applyEditorBlockProps = createHigherOrderComponent(
 				// styles get added to the `wrapperProps` attribute on the BlockListBlock
 				if (
 					Object.keys( control ).includes( 'applyStyleProperty' ) &&
-					attributes[ control.attribute ] &&
-					attributes[ control.attribute ] !== control.defaultValue
+					attributes[ control.attribute ] !== undefined &&
+					( ( control.type === 'toggle' &&
+						attributes[ control.attribute ] ) ||
+						control.type !== 'toggle' )
 				) {
 					styles.style = {
 						[ control.applyStyleProperty ]:
@@ -141,6 +149,7 @@ const determineControlToRender = ( control, attributes, setAttributes ) => {
 	if ( control.type === 'toggle' ) {
 		return (
 			<ToggleControl
+				__nextHasNoMarginBottom={ true }
 				key={ control.attribute }
 				label={ control.label }
 				checked={ attributes[ control.attribute ] }
@@ -203,7 +212,7 @@ const addBlockControls = createHigherOrderComponent( ( BlockEdit ) => {
 
 		// set default attributes if not set
 		state.settings.controls.forEach( ( control ) => {
-			if ( ! attributes[ control.attribute ] ) {
+			if ( attributes[ control.attribute ] === undefined ) {
 				attributes[ control.attribute ] = control.defaultValue;
 			}
 		} );

--- a/wp-content/themes/core/blocks/core/column/editor.js
+++ b/wp-content/themes/core/blocks/core/column/editor.js
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 const settings = {
 	attributes: {
 		stackingOrder: {
-			type: 'string',
+			type: 'number',
 		},
 	},
 	blocks: [ 'core/column' ],


### PR DESCRIPTION
## What does this do/fix?

- Updates Column block `stackingOrder` attribute to be a `number` field to prevent type mismatching when checking / applying the value
- When using `toggle` control types, you previously weren't able to set the `defaultValue` to `true` as there were incorrect checks in place. These checks have been updated to ensure that the `number` and `select` control types continue to function, and the toggle control can now function as it was supposed to. We should now be properly checking if the `toggle` control is set to `true` before applying the class / style rules, instead of just applying them if the value was different than the default. 

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-193)
