### PR TITLE
Add type hints to Post Type subscriber

### DIFF
--- a/wp-content/plugins/core/src/Post_Types/Post_Type_Subscriber.php
+++ b/wp-content/plugins/core/src/Post_Types/Post_Type_Subscriber.php
@@ -9,7 +9,7 @@ abstract class Post_Type_Subscriber extends Abstract_Subscriber {
 	/**
 	 * @var class-string<\Tribe\Plugin\Post_Types\Post_Type_Config>
 	 */
-	protected $config_class;
+	protected string $config_class;
 
 	public function register(): void {
 		if ( ! $this->config_class ) {


### PR DESCRIPTION
## What does this do/fix?

Adds type hints to Post Type subscriber.

## QA

Links to relevant issues
- https://github.com/moderntribe/uscpx/pull/6#discussion_r2079857425