### PR TITLE
Fix misnamed typography variables

### DIFF
--- a/wp-content/themes/core/assets/pcss/parts/footer.pcss
+++ b/wp-content/themes/core/assets/pcss/parts/footer.pcss
@@ -30,7 +30,7 @@
 			text-decoration: underline;
 			text-decoration-thickness: 1px;
 			text-decoration-color: transparent;
-			font-weight: var(--font-weight-normal);
+			font-weight: var(--font-weight-regular);
 			transition: var(--transition);
 
 			&:hover,

--- a/wp-content/themes/core/assets/pcss/typography/_variables.pcss
+++ b/wp-content/themes/core/assets/pcss/typography/_variables.pcss
@@ -31,7 +31,7 @@
 	 * Font Weights
 	 * ------------------------------------------------------------------------- */
 
-	--font-weight-normal: var(--wp--custom--font-weight--regular);
+	--font-weight-regular: var(--wp--custom--font-weight--regular);
 	--font-weight-bold: var(--wp--custom--font-weight--bold);
 
 	/* -------------------------------------------------------------------------


### PR DESCRIPTION
## What does this do/fix?

This fixes a misnamed CSS variable. Note that `--font-weight-regular` is already being used in [our mixins](https://github.com/search?q=repo%3Amoderntribe%2Fmoose%20--font-weight-regular&type=code) although it wasn't defined. 
