### PR TITLE
Revert post title width

### DIFF
--- a/wp-content/themes/core/assets/pcss/global/editor.pcss
+++ b/wp-content/themes/core/assets/pcss/global/editor.pcss
@@ -6,7 +6,6 @@
 
 /* handle styling the editor "title bar" */
 .edit-post-visual-editor__post-title-wrapper {
-	width: 100% !important;
 	margin-top: 0 !important;
 	padding-top: var(--spacer-40);
 	padding-bottom: var(--spacer-40);


### PR DESCRIPTION
## What does this do/fix?

Removes width styling on post title which is causing the title wrapper to overflow the editor screen.

## QA

Screenshots/video:

**Before**
<img width="1273" alt="Screenshot 2025-07-07 at 4 24 31 PM" src="https://github.com/user-attachments/assets/75aed51b-f36e-46c7-8674-d23ba1520fcb" />

**After**
<img width="1273" alt="Screenshot 2025-07-07 at 4 24 44 PM" src="https://github.com/user-attachments/assets/e64c54f5-7773-4606-b6a0-e3f759e1848f" />
