### PR TITLE
[MOOSE-212] Search Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the
 item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2025.07]
+- Updated: 404 & Search templates have been updated to Moose 2.0 design standards.
+- Fixed: Issue with editor pattern / template previews (still using `iframe` elements) displaying at the wrong width.
+
 ## [2025.06]
 - Updated: Post & Search templates now use dynamic custom blocks to render the post cards. [#210](https://moderntribe.atlassian.net/browse/MOOSE-210)
 - Fixed: `reset.pcss` now loads in the editor to fix issues with elements not properly getting `border-box` sizing. Because all editors are now `<iframe>` elements, this should not negatively affect anything outside of the editor like we were worried about before.

--- a/wp-content/themes/core/assets/pcss/global/reset.pcss
+++ b/wp-content/themes/core/assets/pcss/global/reset.pcss
@@ -54,7 +54,7 @@ picture {
 /**
  * Prevent media from overflowing its container.
  */
-iframe,
+body:not(.wp-admin) iframe,
 video,
 embed {
 	max-width: 100%;

--- a/wp-content/themes/core/bindings/Query_Results_Count.php
+++ b/wp-content/themes/core/bindings/Query_Results_Count.php
@@ -28,9 +28,9 @@ class Query_Results_Count extends Binding_Base {
 		global $wp_query;
 		$is_search = is_search();
 		$count     = (int) $wp_query->found_posts;
-		$output    = sprintf( _n( '%d result', '%d results', $count, 'tribe' ), number_format_i18n( $count ) );
+		$output    = $count > 0 ? sprintf( _n( '%d result', '%d results', $count, 'tribe' ), number_format_i18n( $count ) ) : '';
 
-		if ( $is_search ) {
+		if ( $is_search && $count > 0 ) {
 			$output = sprintf(
 				_x(
 					'%s %s for <span class="search-term" style="font-weight:var(--wp--custom--font-weight--bold)">&ldquo;%s&rdquo;</span>',

--- a/wp-content/themes/core/blocks/core/querypagination/style.pcss
+++ b/wp-content/themes/core/blocks/core/querypagination/style.pcss
@@ -3,9 +3,8 @@
  */
 
 .wp-block-query-pagination {
-	align-items: center;
-	gap: 0 24px;
-	margin-top: var(--spacer-40);
+	gap: 0 var(--spacer-40) !important;
+	margin-top: var(--spacer-50) !important;
 
 	/* ensure all links within the pagination get the same styling */
 	& a {
@@ -25,7 +24,7 @@
 	.wp-block-query-pagination-numbers {
 		display: flex;
 		align-items: center;
-		gap: 0 16px;
+		gap: 0 var(--spacer-20);
 		margin: 0;
 
 		.page-numbers {
@@ -35,6 +34,7 @@
 			justify-content: center;
 			height: 40px;
 			width: 40px;
+			border-radius: 100%;
 
 			&:where(:not(.current, .dots)):hover,
 			&:where(:not(.current, .dots)):focus:not(:focus-visible) {
@@ -43,7 +43,7 @@
 
 			/* Current page indicator */
 			&.current {
-				background-color: var(--color-royal-blue);
+				background-color: var(--color-blue);
 				color: var(--color-white);
 			}
 		}
@@ -56,8 +56,14 @@
 	.wp-block-query-pagination-next {
 		display: flex;
 		align-items: center;
-		gap: 0.75rem;
+		gap: 0;
 		margin: 0;
+		font-size: 0;
+
+		@media (--mq-desktop) {
+			gap: var(--spacer-20);
+			font-size: inherit;
+		}
 
 		&:hover,
 		&:focus:not(:focus-visible) {

--- a/wp-content/themes/core/templates/search.html
+++ b/wp-content/themes/core/templates/search.html
@@ -1,37 +1,37 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-<h1 class="wp-block-heading has-text-align-center" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--30)">Search</h1>
-<!-- /wp:heading -->
+<!-- wp:group {"tagName":"main","metadata":{"name":"Search Results"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"metadata":{"name":"Search Results - Header"},"style":{"spacing":{"margin":{"bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-bottom:0"><!-- wp:heading {"textAlign":"center","level":1,"className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+		<h1 class="wp-block-heading has-text-align-center is-style-default" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--30)">Search</h1>
+		<!-- /wp:heading -->
 
-<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /--></div>
-<!-- /wp:group -->
+		<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} /--></div>
+	<!-- /wp:group -->
 
-<!-- wp:paragraph {"align":"wide","metadata":{"bindings":{"content":{"source":"tribe/query-results-count"}}},"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-<p class="has-text-align-wide" style="margin-bottom:var(--wp--preset--spacing--30)"></p>
-<!-- /wp:paragraph -->
+	<!-- wp:group {"metadata":{"name":"Search Results - Results"},"align":"wide","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"align":"wide","metadata":{"bindings":{"content":{"source":"tribe/query-results-count"}}},"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+		<p class="has-text-align-wide" style="margin-bottom:var(--wp--preset--spacing--40)"></p>
+		<!-- /wp:paragraph -->
 
-<!-- wp:query {"queryId":0,"query":{"perPage":"16","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"list","columns":3},"align":"wide"} -->
-<div class="wp-block-query alignwide"><!-- wp:post-template {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default","columnCount":3}} -->
-	<!-- wp:tribe/search-card /-->
-<!-- /wp:post-template -->
+		<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"parents":[],"format":[]},"align":"wide","className":"alignwide s-remove-margin\u002d\u002dtop"} -->
+		<div class="wp-block-query alignwide s-remove-margin--top"><!-- wp:post-template {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default","columnCount":3}} -->
+			<!-- wp:tribe/search-card /-->
+			<!-- /wp:post-template -->
 
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"0"}}}} -->
-<p class="has-text-align-center" style="margin-top:0">Your search query returned no results. Try another search term.</p>
-<!-- /wp:paragraph -->
+			<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"0"}}}} -->
+			<p class="has-text-align-center" style="margin-top:0">Your search returned no results. Please try another search term.</p>
+			<!-- /wp:paragraph -->
+			<!-- /wp:query-no-results -->
 
-<!-- wp:spacer {"height":"50px"} -->
-<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-<!-- /wp:query-no-results -->
+			<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
 
-<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
-<!-- wp:query-pagination-numbers /-->
-<!-- wp:query-pagination-next {"label":"Next Page"} /-->
-<!-- /wp:query-pagination --></div>
-<!-- /wp:query --></main>
+			<!-- wp:query-pagination-numbers /-->
+
+			<!-- wp:query-pagination-next {"label":"Next Page"} /-->
+			<!-- /wp:query-pagination --></div>
+		<!-- /wp:query --></div>
+	<!-- /wp:group --></main>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
## What does this do/fix?

- fixes issues where `iframe` elements display in the editor (pattern / template previews) were getting overwritten by the inclusion of the reset in the editor CSS
- updates Query Results Count binding to not display any content when there aren't any results
- update pagination styling
- update search results template

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-212)

Screenshots/video:
- Search Results: http://p.tri.be/i/rd3gAU
- Updated pagination: http://p.tri.be/i/1YYMPe
- Mobile: http://p.tri.be/i/6kY1Ic
- No results: http://p.tri.be/i/2tW3nd
