### PR TITLE
[MOOSE-201] Style Core Details Block

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -9,6 +9,7 @@ use Tribe\Theme\bindings\Query_Results_Count;
 use Tribe\Theme\blocks\core\button\Button;
 use Tribe\Theme\blocks\core\column\Column;
 use Tribe\Theme\blocks\core\columns\Columns;
+use Tribe\Theme\blocks\core\details\Details;
 use Tribe\Theme\blocks\core\embed\Embed;
 use Tribe\Theme\blocks\core\image\Image;
 use Tribe\Theme\blocks\core\lists\Lists;
@@ -46,6 +47,7 @@ class Blocks_Definer implements Definer_Interface {
 				DI\get( Button::class ),
 				DI\get( Column::class ),
 				DI\get( Columns::class ),
+				DI\get( Details::class ),
 				DI\get( Embed::class ),
 				DI\get( Image::class ),
 				DI\get( Lists::class ),

--- a/wp-content/themes/core/blocks/core/details/Details.php
+++ b/wp-content/themes/core/blocks/core/details/Details.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Theme\blocks\core\details;
+
+use Tribe\Plugin\Blocks\Block_Base;
+
+class Details extends Block_Base {
+
+	public function get_block_name(): string {
+		return 'core/details';
+	}
+
+}

--- a/wp-content/themes/core/blocks/core/details/index.js
+++ b/wp-content/themes/core/blocks/core/details/index.js
@@ -1,0 +1,5 @@
+/**
+ * Scripts specific to this block
+ */
+
+import './style.pcss';

--- a/wp-content/themes/core/blocks/core/details/style.pcss
+++ b/wp-content/themes/core/blocks/core/details/style.pcss
@@ -1,0 +1,72 @@
+/**
+ * Styles specific to this block
+ */
+.wp-block-details {
+
+	summary {
+		display: list-item;
+		cursor: pointer;
+		list-style: none;
+		position: relative;
+		padding-right: 20px;
+
+		/* Arrow */
+		&::after {
+			content: "";
+			display: block;
+			width: 10px;
+			height: 16px;
+			position: absolute;
+			right: 0;
+			top: 50%;
+			transform: translateY(-50%) rotate(90deg);
+			mask: var(--icon-chevron-right) center no-repeat;
+			mask-size: contain;
+			background-color: currentcolor;
+			transition: var(--transition);
+		}
+	}
+
+	/* Opened */
+	&[open] > summary::after {
+	  transform: translateY(-50%) rotate(-90deg);
+	}
+
+	/* Dark style */
+	.is-style-dark & {
+		border-bottom-color: var(--color-white);
+
+		&:first-child {
+			border-top-color: var(--color-white);
+		}
+	}
+
+	/**
+	* Remove margin between items for grouped together <details>
+	* Ensure the <details> block is the first child of the group,
+	* then target its siblings.
+	**/
+	.wp-block-group > &:first-child ~ & {
+		border-top: 0;
+		margin-top: 0;
+	}
+
+	/* Add animation to the content */
+	&[open] summary ~ * {
+		animation: sweep 0.3s ease-in-out;
+	}
+}
+
+/* Custom animation for the content  */
+@keyframes sweep {
+
+	0% {
+		opacity: 0;
+		transform: translateX(-10px);
+	}
+
+	100% {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -144,6 +144,11 @@
 					"slug": "neutral-10"
 				},
 				{
+					"color": "#d1d1d1",
+					"name": "Neutral 30",
+					"slug": "neutral-30"
+				},
+				{
 					"color": "#767676",
 					"name": "Neutral 50",
 					"slug": "neutral-50"
@@ -357,6 +362,32 @@
 			"background": "var(--wp--preset--color--base-white)"
 		},
 		"blocks": {
+			"core/details": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "var(--wp--preset--font-size--30)",
+					"lineHeight": "1.4",
+					"fontWeight": "var(--wp--custom--font-weight--bold)"
+				},
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--preset--spacing--40)",
+						"bottom": "var(--wp--preset--spacing--40)"
+					}
+				},
+				"border": {
+					"top": {
+						"color": "var(--wp--preset--color--neutral-30)",
+						"style": "solid",
+						"width": "1px"
+					},
+					"bottom": {
+						"color": "var(--wp--preset--color--neutral-30)",
+						"style": "solid",
+						"width": "1px"
+					}
+				}
+			},
 			"core/embed": {
 				"elements": {
 					"caption": {


### PR DESCRIPTION
## What does this do/fix?

Styles the `core/details` block.

I also added the `--color--neutral-30` to the `theme.json` color palette.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-201)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/ea5c40d4668349c2b6c3fdaa4e876a4e?sid=76a968f0-6df9-41b1-a12a-801e0cf7968a)
