### PR TITLE
[MOOSE-224] Integrate Tabs Custom Block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "moose",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"delegate": "^3.2.0"
+			},
 			"devDependencies": {
 				"@csstools/postcss-global-data": "^3.0.0",
 				"@wordpress/create-block": "^4.65.0",
@@ -10632,6 +10635,12 @@
 			"engines": {
 				"node": ">=0.4.0"
 			}
+		},
+		"node_modules/delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"license": "MIT"
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
 		"coreThemeBlocksDir": "./wp-content/themes/core/blocks",
 		"coreBlockTemplatesDir": "../../../../../dev/templates"
 	},
+	"dependencies": {
+		"delegate": "^3.2.0"
+	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
 		"@wordpress/create-block": "^4.65.0",

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -39,6 +39,8 @@ class Blocks_Definer implements Definer_Interface {
 				'tribe/copyright',
 				'tribe/post-card',
 				'tribe/search-card',
+				'tribe/tab',
+				'tribe/tabs',
 				'tribe/terms',
 			] ),
 

--- a/wp-content/themes/core/blocks/tribe/tab/block.json
+++ b/wp-content/themes/core/blocks/tribe/tab/block.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/tab",
+	"version": "0.1.0",
+	"title": "Tab",
+	"category": "theme",
+	"description": "Child of Tabs block",
+	"icon": "text-page",
+	"parent": [ "tribe/tabs" ],
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": false,
+			"padding": true
+		}
+	},
+	"attributes": {
+		"blockId": {
+			"type": "string",
+			"default": ""
+		},
+		"tabLabel": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"usesContext": [ "tribe/tabs/currentActiveTabInstanceId" ],
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css"
+}

--- a/wp-content/themes/core/blocks/tribe/tab/edit.js
+++ b/wp-content/themes/core/blocks/tribe/tab/edit.js
@@ -1,0 +1,27 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { useInstanceId } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
+
+import './editor.pcss';
+
+export default function Edit( { context, setAttributes } ) {
+	const activeTab = context[ 'tribe/tabs/currentActiveTabInstanceId' ];
+	const instanceId = useInstanceId( Edit, 'tab-content' );
+	const blockProps = useBlockProps( {
+		className: activeTab === instanceId ? 'active-tab' : '',
+	} );
+
+	useEffect( () => {
+		setAttributes( {
+			blockId: instanceId,
+		} );
+	}, [ instanceId, setAttributes ] );
+
+	const TAB_TEMPLATE = [ [ 'core/paragraph' ] ];
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks template={ TAB_TEMPLATE } />
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/tab/editor.pcss
+++ b/wp-content/themes/core/blocks/tribe/tab/editor.pcss
@@ -1,0 +1,7 @@
+.wp-block-tribe-tab {
+	display: none;
+
+	&.active-tab {
+		display: block;
+	}
+}

--- a/wp-content/themes/core/blocks/tribe/tab/index.js
+++ b/wp-content/themes/core/blocks/tribe/tab/index.js
@@ -1,0 +1,34 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import Edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	icon: (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M1.5 2.25H7.62488H9.125H13.3749H14.5024H20.2524V6.5H22.25V18.75C22.25 19.413 21.9866 20.0489 21.5178 20.5178C21.0489 20.9866 20.413 21.25 19.75 21.25H4C3.33696 21.25 2.70107 20.9866 2.23223 20.5178C1.76339 20.0489 1.5 19.413 1.5 18.75V2.25ZM18.7524 6.5V3.75H14.8749V6.5H18.7524ZM3 3.75H7.62488V7.25H7.625V8H20.75V18.75C20.75 19.0152 20.6446 19.2696 20.4571 19.4571C20.2696 19.6446 20.0152 19.75 19.75 19.75H4C3.73478 19.75 3.48043 19.6446 3.29289 19.4571C3.10536 19.2696 3 19.0152 3 18.75V3.75ZM9.125 6.5V3.75H13.0024V6.5H9.125Z"
+				fill="black"
+			/>
+		</svg>
+	),
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} );

--- a/wp-content/themes/core/blocks/tribe/tab/save.js
+++ b/wp-content/themes/core/blocks/tribe/tab/save.js
@@ -1,0 +1,21 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function save( props ) {
+	const {
+		attributes: { blockId },
+	} = props;
+
+	const blockProps = useBlockProps.save( {
+		id: blockId,
+		role: 'tabpanel',
+		tabindex: '0',
+		hidden: true,
+		'aria-labelledby': 'button-' + blockId,
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/tabs/block.json
+++ b/wp-content/themes/core/blocks/tribe/tabs/block.json
@@ -1,0 +1,49 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/tabs",
+	"version": "0.1.0",
+	"title": "Tabs",
+	"category": "theme",
+	"description": "Allows creation of tabbed content",
+	"icon": "slides",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"currentActiveTabInstanceId": "tab-content-0",
+			"tabs": [
+				{
+					"clientId": "12345",
+					"id": "tab-content-0",
+					"label": "Tab Label",
+					"isActive": true
+				}
+			]
+		}
+	},
+	"attributes": {
+		"currentActiveTabInstanceId": {
+			"type": "string",
+			"default": ""
+		},
+		"tabs": {
+			"type": "array",
+			"default": []
+		}
+	},
+	"providesContext": {
+		"tribe/tabs/currentActiveTabInstanceId": "currentActiveTabInstanceId"
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
+}

--- a/wp-content/themes/core/blocks/tribe/tabs/edit.js
+++ b/wp-content/themes/core/blocks/tribe/tabs/edit.js
@@ -1,0 +1,226 @@
+/**
+ * WordPress Dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import {
+	useBlockProps,
+	RichText,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { Button, Flex, FlexItem } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { SVG, Path } from '@wordpress/primitives';
+
+import './editor.pcss';
+
+export default function Edit( { clientId, attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const dispatch = useDispatch( 'core/block-editor' );
+	const { removeBlocks } = useDispatch( 'core/block-editor' );
+	const select = useSelect( 'core/block-editor' );
+	const innerBlocks = select.getBlocks( clientId );
+	const { currentActiveTabInstanceId, tabs } = attributes;
+
+	/**
+	 * setup inner block props and add classname to wrapper
+	 */
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-tribe-tabs__tab-content',
+		},
+		{
+			allowedBlocks: [ 'tribe/tab' ],
+			template: [ [ 'tribe/tab' ] ],
+			renderAppender: false,
+		}
+	);
+
+	/**
+	 * Update the current active tab to the client Id of the first tab
+	 * This will only run once when the block is first added to the editor
+	 */
+	useEffect( () => {
+		if ( innerBlocks.length === 0 || currentActiveTabInstanceId !== '' ) {
+			return;
+		}
+
+		setAttributes( {
+			currentActiveTabInstanceId: innerBlocks[ 0 ].attributes.blockId,
+		} );
+	}, [ innerBlocks, setAttributes, currentActiveTabInstanceId ] );
+
+	/**
+	 * set new tab state when innerBlocks or currentActiveTabInstanceId changes
+	 */
+	useEffect( () => {
+		const data = innerBlocks.map( ( tab ) => {
+			return {
+				clientId: tab.clientId,
+				id: tab.attributes.blockId,
+				buttonId: 'button-' + tab.attributes.blockId,
+				label: tab.attributes.tabLabel,
+				isActive: currentActiveTabInstanceId === tab.attributes.blockId,
+			};
+		} );
+
+		setAttributes( {
+			tabs: data,
+		} );
+	}, [ innerBlocks, currentActiveTabInstanceId, setAttributes ] );
+
+	/**
+	 * @function updateTabLabel
+	 *
+	 * @description Dispatch action to matching tab to update its label
+	 *
+	 * @param {string} tabLabel
+	 * @param {string} tabClientId
+	 */
+	const updateTabLabel = ( tabLabel, tabClientId ) => {
+		dispatch.updateBlockAttributes( tabClientId, { tabLabel } );
+	};
+
+	/**
+	 * @function addNewTab
+	 *
+	 * @description adds a new tab and an InnerBlock to match
+	 *
+	 * @param {number} positionToAdd
+	 */
+	const addNewTab = ( positionToAdd = innerBlocks.length ) => {
+		// create block
+		const newTab = createBlock( 'tribe/tab' );
+
+		// add new tab
+		dispatch
+			.insertBlock( newTab, positionToAdd, clientId, true )
+			.then( () => {
+				// dispatch will return us a promise which we can use to set our new active tab instanceId
+				const newInstanceId =
+					select.getBlocks( clientId )[ positionToAdd ].attributes
+						.blockId;
+
+				// set new tab as active
+				setAttributes( {
+					currentActiveTabInstanceId: newInstanceId,
+				} );
+			} );
+	};
+
+	/**
+	 * @function deleteTab
+	 *
+	 * @description handles removing tab & InnerBlock based on index
+	 *
+	 * @param {number} index
+	 * @param {string} tabInstanceId
+	 * @param {string} tabClientId
+	 */
+	const deleteTab = ( index, tabInstanceId, tabClientId ) => {
+		// remove block from InnerBlocks
+		removeBlocks( tabClientId );
+
+		// Fetch new inner blocks
+		const newInnerBlocks = select.getBlocks( clientId );
+
+		// Add a new tab if we've deleted the last one
+		if ( newInnerBlocks.length === 0 ) {
+			addNewTab( newInnerBlocks.length );
+
+			return;
+		}
+
+		// decide which block should be the new selected block
+		let newActiveTabInstanceId = currentActiveTabInstanceId;
+
+		if ( newActiveTabInstanceId === tabInstanceId ) {
+			// if we want the first block, show new "first block", any other tab, use the "next" tab
+			newActiveTabInstanceId =
+				index === 0
+					? newInnerBlocks[ index ].attributes.blockId
+					: newInnerBlocks[ index - 1 ].attributes.blockId;
+		}
+
+		setAttributes( {
+			currentActiveTabInstanceId: newActiveTabInstanceId,
+		} );
+	};
+
+	return (
+		<div { ...blockProps }>
+			<Flex
+				className="wp-block-tribe-tabs__tabs"
+				align="center"
+				justify="flex-start"
+			>
+				{ tabs.map( ( tab, index ) => (
+					<FlexItem
+						className={
+							'wp-block-tribe-tabs__tab' +
+							( currentActiveTabInstanceId === tab.id
+								? ' active-tab'
+								: '' )
+						}
+						key={ 'tab-' + tab.id }
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'flex-start',
+							gap: 'var(--spacer-10)',
+						} }
+						onClick={ () => {
+							setAttributes( {
+								currentActiveTabInstanceId: tab.id,
+							} );
+						} }
+					>
+						<RichText
+							tagName="span"
+							className="wp-block-tribe-tabs__tab-label"
+							value={ tab.label }
+							onChange={ ( value ) =>
+								updateTabLabel( value, tab.clientId )
+							}
+							allowedFormats={ [] }
+							placeholder={ __( 'Tab Label', 'tribe' ) }
+						/>
+						<Button
+							className="wp-block-tribe-tabs__tab-delete"
+							variant="link"
+							onClick={ ( e ) => {
+								e.stopPropagation();
+								deleteTab( index, tab.id, tab.clientId );
+							} }
+						>
+							<span
+								style={ {
+									display: 'inline-flex',
+									width: '24px',
+									height: '24px',
+								} }
+							>
+								<SVG
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 24 24"
+								>
+									<Path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z" />
+								</SVG>
+							</span>
+						</Button>
+					</FlexItem>
+				) ) }
+				<FlexItem
+					className="wp-block-tribe-tabs__add"
+					justify="flex-start"
+				>
+					<Button variant="primary" onClick={ () => addNewTab() }>
+						{ __( 'Add New Tab', 'tribe' ) }
+					</Button>
+				</FlexItem>
+			</Flex>
+			<div { ...innerBlocksProps } />
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/tabs/editor.pcss
+++ b/wp-content/themes/core/blocks/tribe/tabs/editor.pcss
@@ -1,0 +1,56 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-tribe-tabs__tabs {
+	gap: 0 !important;
+	border: 1px solid var(--theme-border-color, var(--color-black));
+}
+
+.wp-block-tribe-tabs__tab {
+	position: relative;
+	padding: var(--spacer-20);
+	cursor: pointer;
+	border-right: 1px solid var(--theme-border-color, var(--color-black));
+
+	&.active-tab {
+		position: relative;
+
+		&::after {
+			content: "";
+			display: block;
+			width: 100%;
+			height: 1px;
+			position: absolute;
+			bottom: -1px;
+			left: 0;
+			background-color: var(--theme-background-color, var(--color-white));
+		}
+	}
+}
+
+.wp-block-tribe-tabs__tab-label {
+	cursor: text;
+}
+
+.wp-block-tribe-tabs__tab-delete {
+	padding: 0 !important;
+	color: var(--theme-text-color, var(--color-text)) !important;
+
+	&:hover,
+	&:focus {
+		color: var(--theme-accent-color, var(--wp-admin-theme-color)) !important;
+	}
+}
+
+.wp-block-tribe-tabs__add {
+	margin-left: var(--spacer-20);
+}
+
+.wp-block-tribe-tabs__tab-content {
+	border: 1px solid var(--theme-border-color, var(--color-black));
+	border-top: 0;
+	padding: var(--spacer-20);
+}

--- a/wp-content/themes/core/blocks/tribe/tabs/index.js
+++ b/wp-content/themes/core/blocks/tribe/tabs/index.js
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import './style.pcss';
+
+import Edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	icon: (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M1.5 2.25H7.62488H9.125H13.3749H14.5024H20.2524V6.5H22.25V18.75C22.25 19.413 21.9866 20.0489 21.5178 20.5178C21.0489 20.9866 20.413 21.25 19.75 21.25H4C3.33696 21.25 2.70107 20.9866 2.23223 20.5178C1.76339 20.0489 1.5 19.413 1.5 18.75V2.25ZM18.7524 6.5V3.75H14.8749V6.5H18.7524ZM3 3.75H7.62488V7.25H7.625V8H20.75V18.75C20.75 19.0152 20.6446 19.2696 20.4571 19.4571C20.2696 19.6446 20.0152 19.75 19.75 19.75H4C3.73478 19.75 3.48043 19.6446 3.29289 19.4571C3.10536 19.2696 3 19.0152 3 18.75V3.75ZM9.125 6.5V3.75H13.0024V6.5H9.125Z"
+				fill="black"
+			/>
+		</svg>
+	),
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} );

--- a/wp-content/themes/core/blocks/tribe/tabs/save.js
+++ b/wp-content/themes/core/blocks/tribe/tabs/save.js
@@ -1,0 +1,44 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function save( props ) {
+	const blockProps = {
+		...useBlockProps.save(),
+		'data-js': 'tabs-block',
+	};
+	const {
+		attributes: { tabs },
+	} = props;
+
+	// TODO: add control for accessible label
+
+	return (
+		<section { ...blockProps }>
+			<div className="wp-block-tribe-tabs__tab-nav">
+				<div className="wp-block-tribe-tabs__tab-list" role="tablist">
+					{ tabs.map( ( tab, index ) => {
+						return (
+							<button
+								key={ tab.id }
+								id={ tab.buttonId }
+								type="button"
+								className="wp-block-tribe-tabs__tab-item-button"
+								aria-controls={ tab.id }
+								role="tab"
+								aria-selected={ index === 0 ? 'true' : 'false' }
+								tabIndex={ index === 0 ? '-1' : false }
+							>
+								{ tab.label !== ''
+									? tab.label
+									: __( 'Tab Label', 'tribe' ) }
+							</button>
+						);
+					} ) }
+				</div>
+			</div>
+			<div className="tab-content">
+				<InnerBlocks.Content />
+			</div>
+		</section>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/tabs/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/tabs/style.pcss
@@ -1,0 +1,52 @@
+.wp-block-tribe-tabs__tab-nav {
+	overflow-x: auto;
+}
+
+.wp-block-tribe-tabs__tab-list {
+	display: inline-flex;
+	align-items: stretch;
+	justify-content: center;
+	gap: var(--spacer-40);
+	min-width: 100%;
+	position: relative;
+	padding: 0;
+	margin-top: 0;
+	margin-bottom: 0;
+	border-bottom: 3px solid var(--theme-border-color, var(--color-neutral-20));
+}
+
+/* keep this for allowing previous versions of the block to still work */
+.wp-block-tribe-tabs__tab-item {
+	display: flex;
+	justify-content: center;
+}
+
+.wp-block-tribe-tabs__tab-item-button {
+
+	@mixin t-display-xx-small;
+	display: flex;
+	justify-content: center;
+	position: relative;
+	z-index: 2;
+	padding: var(--spacer-20);
+	background-color: transparent;
+	border: 0;
+	cursor: pointer;
+	white-space: nowrap;
+	color: var(--theme-text-color, var(--color-text));
+
+	&[aria-selected="true"] {
+		color: var(--theme-accent-color, var(--color-text));
+
+		&::after {
+			content: "";
+			display: block;
+			width: 100%;
+			height: 3px;
+			position: absolute;
+			top: 100%;
+			left: 0;
+			background-color: var(--theme-accent-color, var(--color-text));
+		}
+	}
+}

--- a/wp-content/themes/core/blocks/tribe/tabs/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/tabs/style.pcss
@@ -22,8 +22,6 @@
 }
 
 .wp-block-tribe-tabs__tab-item-button {
-
-	@mixin t-display-xx-small;
 	display: flex;
 	justify-content: center;
 	position: relative;

--- a/wp-content/themes/core/blocks/tribe/tabs/view.js
+++ b/wp-content/themes/core/blocks/tribe/tabs/view.js
@@ -1,0 +1,160 @@
+import delegate from 'delegate';
+
+const el = {
+	tabBlocks: document.querySelectorAll( '[data-js="tabs-block"]' ),
+};
+
+/**
+ * @function initializeTabBlocks
+ *
+ * @description remove hidden attributes from the first tab panel in the block. Unfortunately we can't do this in the save() function due to block editor constraints
+ */
+const initializeTabBlocks = () => {
+	el.tabBlocks.forEach( ( tabBlock ) => {
+		const firstTabPanel = tabBlock.querySelector(
+			'[role="tabpanel"]:first-child'
+		);
+
+		firstTabPanel.removeAttribute( 'hidden' );
+	} );
+};
+
+/**
+ * @function handleTabListKeyDown
+ *
+ * @description handle keyboard events within the tablist
+ *
+ * @param {*} e
+ */
+const handleTabListKeyDown = ( e ) => {
+	// bail early if the key event isn't the left or right arrow keys
+	const keyEvents = [ 'ArrowLeft', 'ArrowRight' ];
+
+	if ( ! keyEvents.includes( e.key ) ) {
+		return;
+	}
+
+	// get element indicies to determine where to go next
+	const container = e.delegateTarget.closest( '[data-js="tabs-block"]' );
+	const tabButtons = [ ...container.querySelectorAll( '[role="tab"]' ) ];
+	const currentIndex = tabButtons.indexOf(
+		container.ownerDocument.activeElement
+	);
+	const lastIndex = tabButtons.length - 1;
+
+	// handle right arrow key
+	if ( e.key === 'ArrowRight' ) {
+		// If the current trigger is the last, then cycle to the first. Otherwise, go to the next.
+		const nextIndex = currentIndex + 1 > lastIndex ? 0 : currentIndex + 1;
+		switchTabs( tabButtons[ nextIndex ] );
+		tabButtons[ nextIndex ].focus();
+	}
+
+	// handle left arrow key
+	if ( e.key === 'ArrowLeft' ) {
+		// If the current trigger is the first, then cycle to the last. Otherwise, go to the previous.
+		const prevIndex = currentIndex - 1 < 0 ? lastIndex : currentIndex - 1;
+		switchTabs( tabButtons[ prevIndex ] );
+		tabButtons[ prevIndex ].focus();
+	}
+};
+
+/**
+ * @function hideTabPanel
+ *
+ * @description actions required to hide a particular tab
+ *
+ * @param {*} tab
+ * @param {*} trigger
+ */
+const hideTabPanel = ( tab, trigger ) => {
+	tab.setAttribute( 'hidden', true );
+	trigger.setAttribute( 'aria-selected', 'false' );
+	trigger.setAttribute( 'tabindex', '-1' );
+};
+
+/**
+ * @function showTabPanel
+ *
+ * @description actions required to show a particular tab
+ *
+ * @param {*} tab
+ * @param {*} trigger
+ */
+const showTabPanel = ( tab, trigger ) => {
+	tab.removeAttribute( 'hidden' );
+	trigger.setAttribute( 'aria-selected', 'true' );
+	trigger.removeAttribute( 'tabindex' );
+};
+
+/**
+ * @function switchTabs
+ *
+ * @description handles switching the selected tab
+ *
+ * @param {*} targetTabButton
+ */
+const switchTabs = ( targetTabButton ) => {
+	// check if aria-controls is set
+	const selectedTabId = targetTabButton.getAttribute( 'aria-controls' );
+
+	if ( ! selectedTabId ) {
+		return;
+	}
+
+	// grab all tab panels
+	const container = targetTabButton.closest( '[data-js="tabs-block"]' );
+	const tabs = container.querySelectorAll( '[role="tabpanel"]' );
+
+	tabs.forEach( ( tab ) => {
+		// grab tab button via the aria-labelledby attribute
+		const tabButton = container.querySelector(
+			`#${ tab.getAttribute( 'aria-labelledby' ) }`
+		);
+
+		// determine if we should hide or show this specific panel
+		( tab.id === selectedTabId ? showTabPanel : hideTabPanel )(
+			tab,
+			tabButton
+		);
+	} );
+};
+
+/**
+ * @function handleTabClick
+ *
+ * @description handle click on tab element
+ *
+ * @param {*} e
+ */
+const handleTabClick = ( e ) =>
+	e.delegateTarget.getAttribute( 'aria-selected' ) === 'false'
+		? switchTabs( e.delegateTarget )
+		: false;
+
+/**
+ * @function bindEvents
+ *
+ * @description bind events to elements related to the module
+ */
+const bindEvents = () => {
+	delegate( el.tabBlocks, '[role="tab"]', 'click', handleTabClick );
+	delegate(
+		el.tabBlocks,
+		'[role="tablist"]',
+		'keydown',
+		handleTabListKeyDown
+	);
+};
+
+/**
+ * @function init
+ *
+ * @description kick off the functionality
+ */
+const init = () => {
+	bindEvents();
+	initializeTabBlocks();
+};
+
+init();

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -572,6 +572,14 @@
 					"fontSize": "var(--wp--preset--font-size--10)",
 					"fontWeight": "var(--wp--custom--font-weight--regular)"
 				}
+			},
+			"tribe/tab": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--preset--spacing--60)",
+						"bottom": "var(--wp--preset--spacing--60)"
+					}
+				}
 			}
 		},
 		"elements": {


### PR DESCRIPTION
## What does this do/fix?

It adds the Tribe Tabs block and applies styles to match the [Figma design](https://www.figma.com/design/X4XME8L48tb3IoucXVhdEU/Moose-Website-Design-System-2.0?node-id=7053-2895&t=cbDfxrHbtXAnEuYP-4).

- Styles the item button font
- Adds default padding in `theme.json`

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-224)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/b260c44f26084a23bf685ca0e7577105?sid=22227fb9-c49e-45d1-a68c-2697263c39e6)
