### PR TITLE
[MOOSE-245] Animation Library

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -4,6 +4,7 @@ namespace Tribe\Plugin\Blocks;
 
 use Tribe\Plugin\Blocks\Bindings\Binding_Registrar;
 use Tribe\Plugin\Blocks\Filters\Contracts\Filter_Factory;
+use Tribe\Plugin\Blocks\Helpers\Block_Animation_Attributes;
 use Tribe\Plugin\Blocks\Patterns\Pattern_Category;
 use Tribe\Plugin\Blocks\Patterns\Pattern_Registrar;
 use Tribe\Plugin\Core\Abstract_Subscriber;
@@ -88,6 +89,13 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 
 			return $filter ? $filter->filter_block_content( $block_content, $parsed_block, $block ) : $block_content;
 		}, 10, 3 );
+
+		/**
+		 * Add support for block animation attributes in dynamic blocks.
+		 */
+		add_action( 'wp_loaded', function (): void {
+			$this->container->get( Block_Animation_Attributes::class )->register_animation_attributes();
+		}, 100, 0 );
 
 		/**
 		 * Disable default WP block patterns.

--- a/wp-content/plugins/core/src/Blocks/Helpers/Block_Animation_Attributes.php
+++ b/wp-content/plugins/core/src/Blocks/Helpers/Block_Animation_Attributes.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Blocks\Helpers;
+
+class Block_Animation_Attributes {
+
+	protected string $animation_type               = 'none';
+	protected string $animation_direction          = 'bottom';
+	protected string $animation_duration           = '0.6s';
+	protected string $animation_delay              = '0s';
+	protected bool $animation_disable_mobile_delay = false;
+	protected string $animation_easing             = 'cubic-bezier(0.390, 0.575, 0.565, 1.000)';
+	protected bool $animation_trigger              = false;
+	protected string $animation_position           = '25';
+
+	public function __construct( array $attributes = [] ) {
+		$this->animation_type = $attributes['animationType'] ?? 'none';
+
+		if ( $this->animation_type === 'none' ) {
+			return;
+		}
+
+		$this->animation_direction            = $attributes['animationDirection'];
+		$this->animation_duration             = $attributes['animationDuration'];
+		$this->animation_delay                = $attributes['animationDelay'];
+		$this->animation_disable_mobile_delay = $attributes['animationMobileDisableDelay'];
+		$this->animation_easing               = $attributes['animationEasing'];
+		$this->animation_trigger              = $attributes['animationTrigger'];
+		$this->animation_position             = $attributes['animationPosition'];
+	}
+
+	public function register_animation_attributes(): void {
+		$blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+		foreach ( $blocks as $block ) {
+			/**
+			 * in order to grab dynamic blocks, we should check if the block has a render callback
+			 * if it does not, we can skip it as it is likely a static block - sometimes the
+			 * render callback is a string, so we need to check for that as well
+			 */
+			if ( is_null( $block->render_callback ) || is_string( $block->render_callback ) ) {
+				continue;
+			}
+
+			$animation_attributes = [
+				'animationType'               => [
+					'type'    => 'string',
+					'default' => 'none',
+				],
+				'animationDirection'          => [
+					'type'    => 'string',
+					'default' => 'bottom',
+				],
+				'showAdvancedControls'        => [
+					'type'    => 'boolean',
+					'default' => false,
+				],
+				'animationDuration'           => [
+					'type'    => 'string',
+					'default' => '0.6s',
+				],
+				'animationDelay'              => [
+					'type'    => 'string',
+					'default' => '0s',
+				],
+				'animationMobileDisableDelay' => [
+					'type'    => 'boolean',
+					'default' => false,
+				],
+				'animationEasing'             => [
+					'type'    => 'string',
+					'default' => 'cubic-bezier(0.390, 0.575, 0.565, 1.000)',
+				],
+				'animationTrigger'            => [
+					'type'    => 'boolean',
+					'default' => false,
+				],
+				'animationPosition'           => [
+					'type'    => 'string',
+					'default' => '25',
+				],
+			];
+
+			$block->attributes = array_merge( $block->attributes, $animation_attributes );
+		}
+	}
+
+	public function get_classes(): string {
+		if ( $this->animation_type === 'none' ) {
+			return '';
+		}
+
+		$classes = "is-animated-on-scroll-{$this->animation_position} tribe-animation-type-{$this->animation_type} tribe-animation-direction-{$this->animation_direction}";
+
+		if ( $this->animation_disable_mobile_delay ) {
+			$classes .= ' tribe-animation-mobile-disable-delay';
+		}
+
+		if ( $this->animation_trigger ) {
+			$classes .= ' tribe-animate-multiple';
+		}
+
+		return $classes;
+	}
+
+	public function get_styles(): string {
+		$styles = '';
+
+		if ( $this->animation_type === 'none' ) {
+			return $styles;
+		}
+
+		if ( $this->animation_duration ) {
+			$styles .= "--tribe-animation-speed: {$this->animation_duration};";
+
+			$animation_offset = $this->get_animation_offset( $this->animation_duration );
+			$styles          .= "--tribe-animation-offset: {$animation_offset};";
+		}
+
+		if ( $this->animation_delay ) {
+			$styles .= "--tribe-animation-delay: {$this->animation_delay};";
+		}
+
+		if ( $this->animation_easing ) {
+			$styles .= "--tribe-animation-easing: {$this->animation_easing};";
+		}
+
+		return $styles;
+	}
+
+	protected function get_animation_offset( string $duration ): string {
+		$default_values = [
+			'0.3s' => '20px',
+			'0.6s' => '50px',
+			'0.9s' => '90px',
+			'1.2s' => '160px',
+			'1.4s' => '280px',
+		];
+
+		/**
+		 * typically we would grab the values set in theme.json here
+		 * but it might be too taxing to do so as it would involve
+		 * reading from the filesystem for every block that needs to
+		 * render the animation offset, so I'm hardcoding the defaults
+		 * here so they can be easily updated if necessary.
+		 */
+
+		return $default_values[ $duration ];
+	}
+
+}

--- a/wp-content/plugins/core/src/Blocks/Helpers/Terms_Block.php
+++ b/wp-content/plugins/core/src/Blocks/Helpers/Terms_Block.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Tribe\Plugin\Blocks;
+namespace Tribe\Plugin\Blocks\Helpers;
 
 use Tribe\Plugin\Templates\Traits\Primary_Term;
 

--- a/wp-content/themes/core/assets/js/editor/block-animations/index.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/index.js
@@ -1,0 +1,484 @@
+/**
+ * @module block-animation
+ *
+ * @description handles setting up animation settings for blocks
+ */
+
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	Button,
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import animationSettings from './settings';
+
+/**
+ * @function applyAnimationProps
+ *
+ * @description updates props on the block with new animation settings
+ *
+ * @param {Object} props
+ * @param {Object} block
+ * @param {Object} attributes
+ *
+ * @return {Object} updated props object
+ */
+const applyAnimationProps = ( props, block, attributes ) => {
+	// return default props if block isn't in the includes array
+	if (
+		animationSettings.includes.length > 0 &&
+		! animationSettings.includes.includes( block.name )
+	) {
+		return props;
+	}
+
+	// return default props if block is in the excludes array
+	if (
+		animationSettings.excludes.length > 0 &&
+		animationSettings.excludes.includes( block.name )
+	) {
+		return props;
+	}
+
+	const {
+		animationType,
+		animationDirection,
+		animationDuration,
+		animationDelay,
+		animationMobileDisableDelay,
+		animationEasing,
+		animationTrigger,
+		animationPosition,
+	} = attributes;
+
+	if ( animationType === undefined || animationType === 'none' ) {
+		return props;
+	}
+
+	if ( props.className === undefined ) {
+		props.className = '';
+	}
+
+	props.className = `${
+		props.className !== '' ? props.className + ' ' : ''
+	} is-animated-on-scroll-${ animationPosition } tribe-animation-type-${ animationType } tribe-animation-direction-${ animationDirection }`;
+
+	if ( animationDuration !== undefined && animationDuration ) {
+		props.style = {
+			...props.style,
+			'--tribe-animation-speed': animationDuration,
+			'--tribe-animation-offset':
+				animationSettings.offset[ animationDuration ],
+		};
+	}
+
+	if ( animationDelay !== undefined && animationDelay ) {
+		props.style = {
+			...props.style,
+			'--tribe-animation-delay': animationDelay,
+		};
+	}
+
+	if (
+		animationMobileDisableDelay !== undefined &&
+		animationMobileDisableDelay
+	) {
+		props.className = `${ props.className } tribe-animation-mobile-disable-delay`;
+	}
+
+	if ( animationEasing !== undefined && animationEasing ) {
+		props.style = {
+			...props.style,
+			'--tribe-animation-easing': animationEasing,
+		};
+	}
+
+	if ( animationTrigger !== undefined && animationTrigger ) {
+		props.className = `${ props.className } tribe-animate-multiple`;
+	}
+
+	return props;
+};
+
+/**
+ * @function animationControls
+ *
+ * @description creates component that overrides the edit functionality of the block with new animation controls
+ */
+const animationControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		const { attributes, setAttributes, isSelected, name } = props;
+
+		// return default Edit function if block isn't in the includes array
+		if (
+			animationSettings.includes.length > 0 &&
+			! animationSettings.includes.includes( name )
+		) {
+			return <BlockEdit { ...props } />;
+		}
+
+		// return default Edit function if block is in the excludes array
+		if (
+			animationSettings.excludes.length > 0 &&
+			animationSettings.excludes.includes( name )
+		) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const {
+			animationType,
+			animationDirection,
+			showAdvancedControls,
+			animationDuration,
+			animationDelay,
+			animationMobileDisableDelay,
+			animationEasing,
+			animationTrigger,
+			animationPosition,
+		} = attributes;
+
+		let blockClass =
+			attributes.className !== undefined ? attributes.className : '';
+		const blockStyles = { ...props.style };
+
+		if ( animationType !== undefined && animationType !== 'none' ) {
+			// set block class for animation direction & animation position, if it's not set to the default
+			blockClass = `${
+				blockClass !== '' ? blockClass + ' ' : ''
+			}is-animated-on-scroll-${ animationPosition } tribe-animation-type-${ animationType } tribe-animation-direction-${ animationDirection }`;
+
+			// set block styles for animation duration
+			if ( animationDuration !== undefined && animationDuration ) {
+				blockStyles[ '--tribe-animation-speed' ] = animationDuration;
+
+				blockStyles[ '--tribe-animation-offset' ] =
+					animationSettings.offset[ animationDuration ];
+			}
+
+			// set block styles for animation delay
+			if ( animationDelay !== undefined && animationDelay ) {
+				blockStyles[ '--tribe-animation-delay' ] = animationDelay;
+			}
+
+			// set block class for disabling animation delays on mobile
+			if (
+				animationMobileDisableDelay !== undefined &&
+				animationMobileDisableDelay
+			) {
+				blockClass = `${ blockClass } tribe-animation-mobile-disable-delay`;
+			}
+
+			// set block styles for animation easing
+			if ( animationEasing !== undefined && animationEasing ) {
+				blockStyles[ '--tribe-animation-easing' ] = animationEasing;
+			}
+
+			// set block class for triggering animation multiple times
+			if ( animationTrigger !== undefined && animationTrigger ) {
+				blockClass = `${ blockClass } tribe-animate-multiple`;
+			}
+		}
+
+		const blockProps = {
+			...props,
+			attributes: {
+				...attributes,
+				className: blockClass,
+			},
+			style: blockStyles,
+		};
+
+		return (
+			<Fragment>
+				<BlockEdit { ...blockProps } />
+				{ isSelected && (
+					<InspectorControls>
+						<PanelBody
+							title={ __( 'Block Animations', 'tribe' ) }
+							initialOpen={ false }
+						>
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Animation Type', 'tribe' ) }
+								value={ animationType }
+								help={ __(
+									'Animation Type is the type of animation that should run.',
+									'tribe'
+								) }
+								onChange={ ( newValue ) => {
+									setAttributes( {
+										animationType: newValue,
+									} );
+								} }
+								options={ animationSettings.type }
+							/>
+							{ animationType === undefined ||
+								( animationType !== 'none' && (
+									<>
+										<SelectControl
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
+											label={ __(
+												'Animation Direction',
+												'tribe'
+											) }
+											value={ animationDirection }
+											help={ __(
+												'Animation direction is the direction you want the animation to run in.',
+												'tribe'
+											) }
+											onChange={ ( newValue ) => {
+												setAttributes( {
+													animationDirection:
+														newValue,
+												} );
+											} }
+											options={
+												animationSettings.direction[
+													animationType
+												]
+											}
+										/>
+										<Button
+											__next40pxDefaultSize
+											text={
+												showAdvancedControls
+													? __(
+															'Hide Advanced Controls',
+															'tribe'
+													  )
+													: __(
+															'Show Advanced Controls',
+															'tribe'
+													  )
+											}
+											variant="secondary"
+											icon={
+												showAdvancedControls
+													? 'arrow-up-alt2'
+													: 'arrow-down-alt2'
+											}
+											onClick={ () => {
+												setAttributes( {
+													showAdvancedControls:
+														! showAdvancedControls,
+												} );
+											} }
+											style={ { width: '100%' } }
+										/>
+										{ showAdvancedControls && (
+											<div
+												style={ { paddingTop: '16px' } }
+											>
+												<SelectControl
+													__next40pxDefaultSize
+													__nextHasNoMarginBottom
+													label={ __(
+														'Animation Duration',
+														'tribe'
+													) }
+													value={ animationDuration }
+													help={ __(
+														'Animation duration is the speed at which the animation should run.'
+													) }
+													onChange={ ( newValue ) =>
+														setAttributes( {
+															animationDuration:
+																newValue,
+														} )
+													}
+													options={
+														animationSettings.duration
+													}
+												/>
+												<SelectControl
+													__next40pxDefaultSize
+													__nextHasNoMarginBottom
+													label={ __(
+														'Animation Delay',
+														'tribe'
+													) }
+													value={ animationDelay }
+													help={ __(
+														'Animation delay adds extra time before the animation starts.',
+														'tribe'
+													) }
+													onChange={ ( newValue ) =>
+														setAttributes( {
+															animationDelay:
+																newValue,
+														} )
+													}
+													options={
+														animationSettings.delay
+													}
+												/>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Animation delays should be disabled on mobile.',
+														'tribe'
+													) }
+													help={ __(
+														"Default functionality will not disable animation delays on mobile. This feature is useful for animations that are delayed on desktop, but shouldn't be on mobile.",
+														'tribe'
+													) }
+													checked={
+														!! animationMobileDisableDelay
+													}
+													onChange={ ( newValue ) =>
+														setAttributes( {
+															animationMobileDisableDelay:
+																newValue,
+														} )
+													}
+												/>
+												<SelectControl
+													__next40pxDefaultSize
+													__nextHasNoMarginBottom
+													label={ __(
+														'Animation Easing',
+														'tribe'
+													) }
+													value={ animationEasing }
+													help={ __(
+														'Animation easing determines what easing function the animation should use.',
+														'tribe'
+													) }
+													onChange={ ( newValue ) =>
+														setAttributes( {
+															animationEasing:
+																newValue,
+														} )
+													}
+													options={
+														animationSettings.easing
+													}
+												/>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Animation should trigger every time the element is in the viewport',
+														'tribe'
+													) }
+													help={ __(
+														'Default functionality is to trigger the animation once.',
+														'tribe'
+													) }
+													checked={
+														!! animationTrigger
+													}
+													onChange={ ( newValue ) =>
+														setAttributes( {
+															animationTrigger:
+																newValue,
+														} )
+													}
+												/>
+												<SelectControl
+													__next40pxDefaultSize
+													__nextHasNoMarginBottom
+													label={ __(
+														'Animation Trigger Position',
+														'tribe'
+													) }
+													value={ animationPosition }
+													help={ __(
+														'Animation trigger position determines how much of the element should be in the viewport before the animation triggers.',
+														'tribe'
+													) }
+													onChange={ ( newValue ) =>
+														setAttributes( {
+															animationPosition:
+																newValue,
+														} )
+													}
+													options={
+														animationSettings.position
+													}
+												/>
+											</div>
+										) }
+									</>
+								) ) }
+						</PanelBody>
+					</InspectorControls>
+				) }
+			</Fragment>
+		);
+	};
+}, 'animationControls' );
+
+/**
+ * @function addAnimationAttributes
+ *
+ * @description add new attributes to blocks for animation settings
+ *
+ * @param {Object} settings
+ * @param {string} name
+ *
+ * @return {Object} returns updates settings object
+ */
+const addAnimationAttributes = ( settings, name ) => {
+	// return default settings if block isn't in the includes array
+	if (
+		animationSettings.includes.length > 0 &&
+		! animationSettings.includes.includes( name )
+	) {
+		return settings;
+	}
+
+	// return default settings if block is in the excludes array
+	if (
+		animationSettings.excludes.length > 0 &&
+		animationSettings.excludes.includes( name )
+	) {
+		return settings;
+	}
+
+	if ( name === 'tribe/terms' ) {
+		console.log( name, settings );
+	}
+
+	if ( settings?.attributes !== undefined ) {
+		settings.attributes = {
+			...settings.attributes,
+			...animationSettings.attributes,
+		};
+	}
+
+	return settings;
+};
+
+/**
+ * @function init
+ *
+ * @description initializes this modules functions
+ */
+const init = () => {
+	addFilter(
+		'blocks.registerBlockType',
+		'tribe/add-animation-options',
+		addAnimationAttributes
+	);
+
+	addFilter(
+		'editor.BlockEdit',
+		'tribe/animation-advanced-control',
+		animationControls
+	);
+
+	addFilter(
+		'blocks.getSaveContent.extraProps',
+		'tribe/apply-animation-classes',
+		applyAnimationProps
+	);
+};
+
+export default init;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/attributes.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/attributes.js
@@ -1,0 +1,46 @@
+/**
+ * @module attributes
+ *
+ * @description creates attributes & their defaults for each animated block
+ */
+
+const attributes = {
+	animationType: {
+		type: 'string',
+		default: 'none',
+	},
+	animationDirection: {
+		type: 'string',
+		default: 'bottom',
+	},
+	showAdvancedControls: {
+		type: 'boolean',
+		default: false,
+	},
+	animationDuration: {
+		type: 'string',
+		default: '0.6s',
+	},
+	animationDelay: {
+		type: 'string',
+		default: '0s',
+	},
+	animationMobileDisableDelay: {
+		type: 'boolean',
+		default: false,
+	},
+	animationEasing: {
+		type: 'string',
+		default: 'cubic-bezier(0.390, 0.575, 0.565, 1.000)',
+	},
+	animationTrigger: {
+		type: 'boolean',
+		default: false,
+	},
+	animationPosition: {
+		type: 'string',
+		default: '25',
+	},
+};
+
+export default attributes;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/delay.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/delay.js
@@ -1,0 +1,27 @@
+/**
+ * @module delay
+ *
+ * @description pulls animation delay settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationDelay": [
+ * 		{ "label": "0", "value": "0s" },
+ * 		{ "label": "200ms", "value": "0.2s" },
+ * 		{ "label": "800ms", "value": "0.8s" }
+ * ],
+ */
+
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../../../theme.json';
+
+const delay = themeJson?.settings?.animationDelay ?? [
+	{ label: __( '0', 'tribe' ), value: '0s' },
+	{ label: __( '300ms', 'tribe' ), value: '0.3s' },
+	{ label: __( '600ms', 'tribe' ), value: '0.6s' },
+	{ label: __( '900ms', 'tribe' ), value: '0.9s' },
+	{ label: __( '1200ms', 'tribe' ), value: '1.2s' },
+	{ label: __( '1500ms', 'tribe' ), value: '1.5s' },
+];
+
+export default delay;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/direction.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/direction.js
@@ -1,0 +1,36 @@
+/**
+ * @module direction
+ *
+ * @description pulls animation direction settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationDirection": {
+ * 		"fade-in": [
+ * 			{ "label": "Top", "value": "top" },
+ * 			{ "label": "Bottom", "value": "bottom" }
+ * 		]
+ * },
+ */
+
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../../../theme.json';
+
+// direction is an object with keys for each animation type
+const direction = themeJson?.settings?.animationDirection ?? {
+	'fade-in': [
+		{ label: __( 'Bottom', 'tribe' ), value: 'bottom' },
+		{ label: __( 'Right', 'tribe' ), value: 'right' },
+		{ label: __( 'Top Right', 'tribe' ), value: 'top-right' },
+		{ label: __( 'Bottom Right', 'tribe' ), value: 'bottom-right' },
+		{ label: __( 'Left', 'tribe' ), value: 'left' },
+		{ label: __( 'Top Left', 'tribe' ), value: 'top-left' },
+		{ label: __( 'Bottom Left', 'tribe' ), value: 'bottom-left' },
+		{ label: __( 'Forward', 'tribe' ), value: 'forward' },
+		{ label: __( 'Back', 'tribe' ), value: 'back' },
+		{ label: __( 'Top', 'tribe' ), value: 'top' },
+		{ label: __( 'Simple', 'tribe' ), value: 'simple' },
+	],
+};
+
+export default direction;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/duration.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/duration.js
@@ -1,0 +1,25 @@
+/**
+ * @module duration
+ *
+ * @description pulls animation duration settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationDuration": [
+ * 		{ "label": "200ms", "value": "0.2s" },
+ * 		{ "label": "800ms", "value": "0.8s" }
+ * ],
+ */
+
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../../../theme.json';
+
+const duration = themeJson?.settings?.animationDuration ?? [
+	{ label: __( '300ms', 'tribe' ), value: '0.3s' },
+	{ label: __( '600ms', 'tribe' ), value: '0.6s' },
+	{ label: __( '900ms', 'tribe' ), value: '0.9s' },
+	{ label: __( '1200ms', 'tribe' ), value: '1.2s' },
+	{ label: __( '1400ms', 'tribe' ), value: '1.4s' },
+];
+
+export default duration;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/easing.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/easing.js
@@ -1,0 +1,44 @@
+/**
+ * @module easing
+ *
+ * @description pulls animation easing settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationEasing": [
+ * 		{ "label": "Ease In", "value": "ease-in" },
+ * 		{ "label": "Ease Out", "value": "ease-out" }
+ * ],
+ */
+
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../../../theme.json';
+
+const easing = themeJson?.settings?.animationEasing ?? [
+	{
+		label: __( 'Ease Out Sine', 'tribe' ),
+		value: 'cubic-bezier(0.390, 0.575, 0.565, 1.000)',
+	},
+	{
+		label: __( 'Ease In Sine', 'tribe' ),
+		value: 'cubic-bezier(0.470, 0.000, 0.745, 0.715)',
+	},
+	{
+		label: __( 'Ease In Out Sine', 'tribe' ),
+		value: 'cubic-bezier(0.445, 0.050, 0.550, 0.950)',
+	},
+	{
+		label: __( 'Ease Out Quad', 'tribe' ),
+		value: 'cubic-bezier(0.250, 0.460, 0.450, 0.940)',
+	},
+	{
+		label: __( 'Ease In Quad', 'tribe' ),
+		value: 'cubic-bezier(0.550, 0.085, 0.680, 0.530)',
+	},
+	{
+		label: __( 'Ease In Out Quad', 'tribe' ),
+		value: 'cubic-bezier(0.455, 0.030, 0.515, 0.955)',
+	},
+];
+
+export default easing;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/excludes.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/excludes.js
@@ -1,0 +1,18 @@
+/**
+ * @module excludes
+ *
+ * @description pulls animation excludes settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationExcludes": [
+ * 		"core/group",
+ * 		"core/heading"
+ * ],
+ */
+
+import themeJson from '../../../../../theme.json';
+
+const excludes = themeJson.settings.animationExcludes ?? [];
+
+export default excludes;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/includes.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/includes.js
@@ -1,0 +1,18 @@
+/**
+ * @module includes
+ *
+ * @description pulls animation includes settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationIncludes": [
+ * 		"core/group",
+ * 		"core/heading"
+ * ],
+ */
+
+import themeJson from '../../../../../theme.json';
+
+const includes = themeJson.settings.animationIncludes ?? [];
+
+export default includes;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/index.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/index.js
@@ -1,0 +1,31 @@
+/**
+ * @module settings
+ *
+ * @description pulls animation attributes / settings
+ */
+
+import attributes from './attributes.js';
+import delay from './delay.js';
+import direction from './direction.js';
+import duration from './duration.js';
+import easing from './easing.js';
+import excludes from './excludes.js';
+import includes from './includes.js';
+import offset from './offset.js';
+import position from './position.js';
+import { default as type } from './type.js'; // type is a reserved word so we need to use default as alias
+
+const settings = {
+	attributes,
+	delay,
+	direction,
+	duration,
+	easing,
+	excludes,
+	includes,
+	offset,
+	position,
+	type,
+};
+
+export default settings;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/offset.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/offset.js
@@ -1,0 +1,24 @@
+/**
+ * @module offset
+ *
+ * @description pulls animation offset settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationOffset": {
+ * 		"0.2s": "20px",
+ * 		"0.8s": "50px"
+ * },
+ */
+
+import themeJson from '../../../../../theme.json';
+
+const offset = themeJson?.settings?.animationOffset ?? {
+	'0.3s': '20px',
+	'0.6s': '50px',
+	'0.9s': '90px',
+	'1.2s': '160px',
+	'1.4s': '280px',
+};
+
+export default offset;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/position.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/position.js
@@ -1,0 +1,24 @@
+/**
+ * @module position
+ *
+ * @description pulls animation position settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationPosition": [
+ * 		{ "label": "25%", "value": "25" },
+ * 		{ "label": "50%", "value": "50" },
+ * ],
+ */
+
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../../../theme.json';
+
+const position = themeJson?.settings?.animationPosition ?? [
+	{ label: __( '25%', 'tribe' ), value: '25' },
+	{ label: __( '50%', 'tribe' ), value: '50' },
+	{ label: __( '75%', 'tribe' ), value: '75' },
+	{ label: __( '100%', 'tribe' ), value: '100' },
+];
+
+export default position;

--- a/wp-content/themes/core/assets/js/editor/block-animations/settings/type.js
+++ b/wp-content/themes/core/assets/js/editor/block-animations/settings/type.js
@@ -1,0 +1,22 @@
+/**
+ * @module type
+ *
+ * @description pulls animation type settings from theme.json or sets default settings
+ *
+ * theme.json settings:
+ *
+ * "animationType": [
+ * 		{ "label": "None", "value": "none" },
+ * 		{ "label": "Fade In", "value": "fade-in" }
+ * ],
+ */
+
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../../../theme.json';
+
+const type = themeJson?.settings?.animationType ?? [
+	{ label: __( 'None', 'tribe' ), value: 'none' },
+	{ label: __( 'Fade In', 'tribe' ), value: 'fade-in' },
+];
+
+export default type;

--- a/wp-content/themes/core/assets/js/editor/ready.js
+++ b/wp-content/themes/core/assets/js/editor/ready.js
@@ -4,13 +4,16 @@
  * @description The core dispatcher for the dom ready event javascript.
  */
 
+import blockAnimations from './block-animations';
+
 /**
  * @function init
  * @description The core dispatcher for init across the codebase.
  */
 
 const init = () => {
-	// intentionally left blank for now
+	// initialize block animation controls in editor
+	blockAnimations();
 
 	console.info(
 		'Editor: Initialized all javascript that targeted document ready.'

--- a/wp-content/themes/core/assets/js/theme/animate-on-scroll.js
+++ b/wp-content/themes/core/assets/js/theme/animate-on-scroll.js
@@ -1,0 +1,107 @@
+/**
+ * @module
+ * @exports init
+ * @description functions for handling elements that should change on scroll
+ */
+
+const el = {};
+
+/**
+ * @function handleIntersection
+ *
+ * @description Callback function for when an element comes into view
+ *
+ * @param {*} entries
+ */
+const handleIntersection = ( entries ) => {
+	entries.forEach( ( entry ) => {
+		if ( entry.isIntersecting ) {
+			entry.target.classList.remove( 'is-exiting-view' );
+			entry.target.classList.add( 'is-scrolled-into-view' );
+			entry.target.classList.add( 'is-scrolled-into-view-first-time' );
+		} else {
+			entry.target.classList.remove( 'is-scrolled-into-view' );
+			entry.target.classList.add( 'is-exiting-view' );
+		}
+	} );
+};
+
+/**
+ * @function attachObservers
+ *
+ * @description attach intersection observers to elements
+ */
+const attachObservers = () => {
+	if ( el.aosElements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 0.25,
+		} );
+
+		el.aosElements.forEach( ( element ) => observer.observe( element ) );
+	}
+
+	if ( el.aos50Elements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 0.5,
+		} );
+
+		el.aos50Elements.forEach( ( element ) => observer.observe( element ) );
+	}
+
+	if ( el.aos75Elements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 0.75,
+		} );
+
+		el.aos75Elements.forEach( ( element ) => observer.observe( element ) );
+	}
+
+	if ( el.aosFullElements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 1,
+		} );
+
+		el.aosFullElements.forEach( ( element ) =>
+			observer.observe( element )
+		);
+	}
+};
+
+/**
+ * @function cacheElements
+ *
+ * @description Cache elements for this module
+ */
+const cacheElements = () => {
+	/**
+	 * Note that the below selectors would need to change if the values of
+	 * the animationPosition values change in theme.json (or the
+	 * block-animations.js file).
+	 */
+
+	// grabs elements that should animate when the element is 25% in view
+	el.aosElements = document.querySelectorAll( '.is-animated-on-scroll-25' );
+
+	// grabs elements that should animate when 50% of the element is in view
+	el.aos50Elements = document.querySelectorAll( '.is-animated-on-scroll-50' );
+
+	// grabs elements that should animate when 75% of the element is in view
+	el.aos75Elements = document.querySelectorAll( '.is-animated-on-scroll-75' );
+
+	// grabs elements that should animate when the entire element is in view
+	el.aosFullElements = document.querySelectorAll(
+		'.is-animated-on-scroll-100'
+	);
+};
+
+/**
+ * @function init
+ *
+ * @description Kick off this module's functionality
+ */
+const init = () => {
+	cacheElements();
+	attachObservers();
+};
+
+export default init;

--- a/wp-content/themes/core/assets/js/theme/ready.js
+++ b/wp-content/themes/core/assets/js/theme/ready.js
@@ -10,6 +10,8 @@ import { debounce } from 'utils/tools.js';
 import resize from 'common/resize.js';
 import viewportDims from 'common/viewport-dims.js';
 
+import animateOnScroll from './animate-on-scroll.js';
+
 /**
  * @function bindEvents
  * @description Bind global event listeners here,
@@ -32,6 +34,10 @@ const init = () => {
 	// initialize global events
 
 	bindEvents();
+
+	// initialize animation on scroll
+
+	animateOnScroll();
 
 	console.info(
 		'Theme: Initialized all javascript that targeted document ready.'

--- a/wp-content/themes/core/assets/pcss/integrations/animation.pcss
+++ b/wp-content/themes/core/assets/pcss/integrations/animation.pcss
@@ -1,0 +1,212 @@
+/* -------------------------------------------------------------------------
+ *
+ * Global: Animations
+ * Works with our block-animations code in core/assets/js/editor along with
+ * our FE IntersectionObserver in core/assets/js/utils/animate-on-scroll.js
+ * to create animations with settings on individual blocks
+ *
+ * ------------------------------------------------------------------------- */
+
+/* Setup default animation variables so they can be overridden per block */
+:root {
+	--tribe-animation-delay: 0s;
+	--tribe-animation-speed: 0.6s;
+	--tribe-animation-easing: cubic-bezier(0.39, 0.575, 0.565, 1);
+	--tribe-animation-offset: 50px;
+}
+
+/* -------------------------------------------------------------------------
+ * Animated Element / Block
+ *
+ * We set opacity to 0 here because all of our animations involve fades
+ * Also set the default transition for the block, if the "Animation should
+ * trigger every time the element is in the viewport" setting is checked,
+ * this transition will handle in & out animations.
+ * ------------------------------------------------------------------------- */
+
+.tribe-animation-type-fade-in {
+
+	/* Only run animations if the users has no preference on reduced motion */
+	@media (prefers-reduced-motion: no-preference) {
+		opacity: 0;
+		transition: opacity var(--tribe-animation-speed) var(--tribe-animation-delay) var(--tribe-animation-easing);
+
+		/* turn off delay for mobile if setting is set */
+		@media (--mq-wp-mobile-max) {
+
+			&.tribe-animation-mobile-disable-delay {
+				transition-delay: 0s !important;
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (Simple)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-simple.is-scrolled-into-view,
+		&:not(.tribe-animate-multiple).tribe-animation-direction-simple.is-scrolled-into-view-first-time {
+			opacity: 1;
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In Up (Bottom)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-bottom {
+			transition-property: all;
+			transform: translateY(var(--tribe-animation-offset));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translateY(0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (from the) Bottom Left (Bottom Left)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-bottom-left {
+			transition-property: all;
+			transform: translate(calc(var(--tribe-animation-offset) * -1), var(--tribe-animation-offset));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translate(0, 0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (from the) Bottom Right (Bottom Right)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-bottom-right {
+			transition-property: all;
+			transform: translate(var(--tribe-animation-offset), var(--tribe-animation-offset));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translate(0, 0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In Down (Top)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-top {
+			transition-property: all;
+			transform: translateY(calc(var(--tribe-animation-offset) * -1));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translateY(0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (from the) Top Right (Top Right)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-top-right {
+			transition-property: all;
+			transform: translate(var(--tribe-animation-offset), calc(var(--tribe-animation-offset) * -1));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translate(0, 0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (from the) Top Left (Top Left)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-top-left {
+			transition-property: all;
+			transform: translate(calc(var(--tribe-animation-offset) * -1), calc(var(--tribe-animation-offset) * -1));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translate(0, 0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (from the) Right (Left)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-left {
+			transition-property: all;
+			transform: translateX(calc(var(--tribe-animation-offset) * -1));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translateX(0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In (from the) Left (Right)
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-right {
+			transition-property: all;
+			transform: translateX(var(--tribe-animation-offset));
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: translateX(0);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In Forward
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-forward {
+			transition-property: all;
+			transform: scale(0.85);
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: scale(1);
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		* Fade In Backward
+		* Don't run "first time" animation if multiple is set
+		* ------------------------------------------------------------------------- */
+
+		&.tribe-animation-direction-back {
+			transition-property: all;
+			transform: scale(1.15);
+
+			&.is-scrolled-into-view,
+			&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+				opacity: 1;
+				transform: scale(1);
+			}
+		}
+	}
+}

--- a/wp-content/themes/core/assets/pcss/theme.pcss
+++ b/wp-content/themes/core/assets/pcss/theme.pcss
@@ -12,6 +12,9 @@
 @import "global/reset.pcss";
 @import "typography/anchors.pcss";
 
+/* Integrations */
+@import "integrations/animation.pcss";
+
 /* Patterns */
 @import "cards/post.pcss";
 @import "cards/post-search-result.pcss";

--- a/wp-content/themes/core/blocks/tribe/post-card/render.php
+++ b/wp-content/themes/core/blocks/tribe/post-card/render.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
 
+use Tribe\Plugin\Blocks\Helpers\Block_Animation_Attributes;
+
 /**
- * @var object $attributes
+ * @var array $attributes
  */
 
-$heading_level = $attributes['headingLevel'];
+$animation_attributes = new Block_Animation_Attributes( $attributes );
+$heading_level        = $attributes['headingLevel'];
 
 /**
  * $_GET['editorPostId'] is set when the block is used in the editor via context
@@ -20,6 +23,7 @@ if ( ! $post_id ) {
 }
 
 get_template_part( 'components/cards/post', null, [
-	'post_id'       => $post_id,
-	'heading_level' => $heading_level,
+	'post_id'              => $post_id,
+	'animation_attributes' => $animation_attributes,
+	'heading_level'        => $heading_level,
 ] );

--- a/wp-content/themes/core/blocks/tribe/search-card/render.php
+++ b/wp-content/themes/core/blocks/tribe/search-card/render.php
@@ -1,5 +1,13 @@
 <?php declare(strict_types=1);
 
+use Tribe\Plugin\Blocks\Helpers\Block_Animation_Attributes;
+
+/**
+ * @var array $attributes
+ */
+
+$animation_attributes = new Block_Animation_Attributes( $attributes );
+
 /**
  * $_GET['editorPostId'] is set when the block is used in the editor via context
  * and is not set when the block is used in the front end, so we don't care too
@@ -14,5 +22,6 @@ if ( ! $post_id ) {
 }
 
 get_template_part( 'components/cards/search', null, [
-	'post_id' => $post_id,
+	'post_id'              => $post_id,
+	'animation_attributes' => $animation_attributes,
 ] );

--- a/wp-content/themes/core/blocks/tribe/terms/render.php
+++ b/wp-content/themes/core/blocks/tribe/terms/render.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
-use Tribe\Plugin\Blocks\Terms_Block;
+use Tribe\Plugin\Blocks\Helpers\Block_Animation_Attributes;
+use Tribe\Plugin\Blocks\Helpers\Terms_Block;
 
 /**
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
@@ -10,8 +11,13 @@ use Tribe\Plugin\Blocks\Terms_Block;
  * @var \WP_Block $block          The instance of the WP_Block class that represents the block being rendered.
  */
 
-$terms_block       = new Terms_Block( $attributes );
-$terms_block_terms = $terms_block->get_the_terms();
+$animation_attributes = new Block_Animation_Attributes( $attributes );
+$terms_block          = new Terms_Block( $attributes );
+$terms_block_terms    = $terms_block->get_the_terms();
+$wrapper_attributes   = get_block_wrapper_attributes([
+	'class' => $animation_attributes->get_classes(),
+	'style' => $animation_attributes->get_styles(),
+]);
 
 // No terms and we're in the block editor
 if ( 0 === count( $terms_block_terms ) && ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
@@ -22,7 +28,7 @@ if ( 0 === count( $terms_block_terms ) && ( defined( 'REST_REQUEST' ) && REST_RE
 	return;
 }
 
-echo '<div ' .  wp_kses_data( get_block_wrapper_attributes() ) . '>';
+echo '<div ' . wp_kses_data( $wrapper_attributes ) . '>';
 echo '<ul class="wp-block-tribe-terms__list">';
 
 foreach ( $terms_block_terms as $term ) {

--- a/wp-content/themes/core/components/cards/post.php
+++ b/wp-content/themes/core/components/cards/post.php
@@ -14,7 +14,8 @@ if ( ! $post_id ) {
 }
 
 // get template part args
-$heading_level = $args['heading_level'] ?? 'h3';
+$animation_attributes = $args['animation_attributes'];
+$heading_level        = $args['heading_level'] ?? 'h3';
 
 // get post data
 $image_id         = get_post_thumbnail_id( $post_id );
@@ -26,7 +27,7 @@ $author           = get_the_author_meta( 'display_name', $author_id );
 $date             = get_the_date( 'M j, Y' );
 $permalink        = get_the_permalink( $post_id );
 ?>
-<article class="c-post-card">
+<article class="c-post-card <?php echo esc_attr( $animation_attributes->get_classes() ); ?>" style="<?php echo esc_attr( $animation_attributes->get_styles() ); ?>">
 	<div class="c-post-card__inner">
 		<?php if ( $image_id ) : ?>
 			<div class="c-post-card__image aspect-ratio-cover aspect-ratio-3-2">

--- a/wp-content/themes/core/components/cards/search.php
+++ b/wp-content/themes/core/components/cards/search.php
@@ -11,6 +11,10 @@ if ( ! $post_id ) {
 	return;
 }
 
+// get template part args
+$animation_attributes = $args['animation_attributes'];
+
+// get post data
 $post_type        = get_post_type( $post_id );
 $post_type_object = get_post_type_object( $post_type );
 $image_id         = get_post_thumbnail_id( $post_id );
@@ -21,7 +25,7 @@ $date             = get_the_date( 'M j, Y' );
 $excerpt          = get_the_excerpt( $post_id );
 $permalink        = get_the_permalink( $post_id );
 ?>
-<article class="c-search-card">
+<article class="c-search-card <?php echo esc_attr( $animation_attributes->get_classes() ); ?>" style="<?php echo esc_attr( $animation_attributes->get_styles() ); ?>">
 	<div class="c-search-card__inner">
 		<?php if ( $image_id ) : ?>
 			<div class="c-search-card__image aspect-ratio-cover aspect-ratio-4-3">


### PR DESCRIPTION
## What does this do/fix?

> [!WARNING]
> The `block-animations/index.js` file is likely collapsed below. This is the main driver file for the editing experience for the block animation library, please be sure to review that file.

> [!IMPORTANT]
> Any dynamic blocks will need to specifically add support for block animations in their render template files. While the `wp_loaded` action _does_ handle adding the attributes, the attributes are unused on dynamic blocks without specifically adding that support. 

> [!IMPORTANT]
> There are currently two places where the animation attributes, their types, and their defaults are set. Once in the `Block_Animation_Attributes` class (PHP) and once in the `attributes.js` file. If anyone has any ideas of how we can possibly avoid this that'd be great. I'd really like to avoid defining those twice. I was thinking maybe a JSON file that I could load in PHP (like we do sometimes for `theme.json`) but I have no idea where to put it.

- Adds block animation support to static & dynamic blocks included in Moose by default. 
- Enables animations on scroll via `IntersectionObserver`
- Support for adding new types of animations (ships with Fade In)
- Adds support for the dynamic PHP blocks that ship with Moose (Terms, Post Card, Search Card). 
    - Note here that the Copyright block is unaffected because it is a static block and the animation attributes get added through the normal JS script.
- Moves the Terms block helper class to the new `Helpers` directory located in the core plugin under `Blocks` 

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-245)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/233c1673d09f4c29b0e190db5b9b2170)
