### PR TITLE
Fix/moose 250/update kses for multisite

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -133,6 +133,25 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 
 			return $tags;
 		}, 10, 2 );
+
+		/**
+		 * Allow cubic-bezier timing function values in inline CSS.
+		 * Example: `<div style="--tribe-animation-easing:cubic-bezier(0.4, 0, 0.2, 1);">`
+		 * The Tribe Animation Library uses cubic-bezier functions to control the timing of animations.
+		 *
+		 * These values are stripped on save if the user doesn't have the `unfiltered_html` capability,
+		 * which admins & editors don't have by default on multisite.
+		 *
+		 * @link https://github.com/WordPress/WordPress/blob/master/wp-includes/kses.php#L2703
+		 */
+		add_filter( 'safecss_filter_attr_allow_css', static function ( bool $allow_css, string $css_test_string ): bool {
+			// Allow cubic-bezier timing function values in inline CSS
+			if ( preg_match( '/cubic-bezier\(([\d.]+,\s*){3}[\d.]+\)/', $css_test_string ) ) {
+				return true;
+			}
+
+			return $allow_css;
+		}, 10, 2 );
 	}
 
 }

--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -115,9 +115,10 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 		} );
 
 		/**
-		 * Allow additional HTML attributes in the post content.
-		 * Multisite only grants the `unsafe_html` capability to Super Admins.
-		 * This is to allow Admins & Editors on multisite to create content using the Tribe Tabs block.
+		 * Allows all roles to publish content containing the Tribe Tabs block.
+		 *
+		 *  These attributes are stripped on save if the user doesn't have the `unfiltered_html` capability,
+		 *  which admins & editors don't have by default on multisite.
 		 *
 		 * @link https://github.com/WordPress/WordPress/blob/master/wp-includes/kses.php#L892
 		 */
@@ -135,8 +136,9 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 		}, 10, 2 );
 
 		/**
-		 * Allow cubic-bezier timing function values in inline CSS.
+		 * Allow all roles to publish content containing `cubic-bezier()` timing function values in inline CSS.
 		 * Example: `<div style="--tribe-animation-easing:cubic-bezier(0.4, 0, 0.2, 1);">`
+		 *
 		 * The Tribe Animation Library uses cubic-bezier functions to control the timing of animations.
 		 *
 		 * These values are stripped on save if the user doesn't have the `unfiltered_html` capability,

--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -113,6 +113,26 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 
 			return $settings;
 		} );
+
+		/**
+		 * Allow additional HTML attributes in the post content.
+		 * Multisite only grants the `unsafe_html` capability to Super Admins.
+		 * This is to allow Admins & Editors on multisite to create content using the Tribe Tabs block.
+		 *
+		 * @link https://github.com/WordPress/WordPress/blob/master/wp-includes/kses.php#L892
+		 */
+		add_filter( 'wp_kses_allowed_html', static function ( array $tags, string $context ): array {
+			if ( $context !== 'post' ) {
+				return $tags;
+			}
+
+			// Tribe Tabs Block needs these attributes to be allowed in the HTML.
+			$tags['button']['tabindex']      = true;
+			$tags['button']['aria-selected'] = true;
+			$tags['div']['tabindex']         = true;
+
+			return $tags;
+		}, 10, 2 );
 	}
 
 }


### PR DESCRIPTION
## What does this do/fix?

Allows several HTML attributes and the `cubic-bezier()` CSS function through Core's kses filters so that all user roles may publish content containing the Tribe Tabs block or Tribe Animations library.

## QA

Links to relevant issues
- [MOOSE-250](https://moderntribe.atlassian.net/browse/MOOSE-250)

### Testing
1. As an Author user on a regular install OR as a Admin or Editor user on Multisite (not a Super Admin):
2. Insert the Tribe Tabs block into a post.
3. Save the post & refresh the page in your browser
4. Confirm the block isn't broken
5. Add some animation options to any block
6. Confirm the block isn't broken and the animation still load correctly on the public website.