### PR TITLE
[MOOSE-248] Logo marquee custom block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",
-				"@dnd-kit/modifiers": "^9.0.0",
 				"@dnd-kit/sortable": "^10.0.0",
 				"@dnd-kit/utilities": "^3.2.2",
 				"@wordpress/icons": "^10.23.0",
@@ -3298,20 +3297,6 @@
 			"peerDependencies": {
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"
-			}
-		},
-		"node_modules/@dnd-kit/modifiers": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
-			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
-			"license": "MIT",
-			"dependencies": {
-				"@dnd-kit/utilities": "^3.2.2",
-				"tslib": "^2.0.0"
-			},
-			"peerDependencies": {
-				"@dnd-kit/core": "^6.3.0",
-				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@dnd-kit/sortable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/modifiers": "^9.0.0",
+				"@dnd-kit/sortable": "^10.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
 				"@wordpress/icons": "^10.23.0",
 				"imagesloaded": "^5.0.0"
 			},
@@ -3267,6 +3271,73 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/modifiers": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "moose",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"imagesloaded": "^5.0.0"
+			},
 			"devDependencies": {
 				"@csstools/postcss-global-data": "^3.0.0",
 				"@wordpress/create-block": "^4.65.0",
@@ -12321,6 +12324,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/ev-emitter": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-2.1.2.tgz",
+			"integrity": "sha512-jQ5Ql18hdCQ4qS+RCrbLfz1n+Pags27q5TwMKvZyhp5hh2UULUYZUy1keqj6k6SYsdqIYjnmz7xyyEY0V67B8Q==",
+			"license": "MIT"
+		},
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -14074,6 +14083,15 @@
 			"integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/imagesloaded": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-5.0.0.tgz",
+			"integrity": "sha512-/0JGSubc1MTCoDKVmonLHgbifBWHdyLkun+R/151E1c5n79hiSxcd7cB7mPXFgojYu8xnRZv7GYxzKoxW8BetQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ev-emitter": "^2.1.2"
+			}
 		},
 		"node_modules/immediate": {
 			"version": "3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/icons": "^10.23.0",
 				"imagesloaded": "^5.0.0"
 			},
 			"devDependencies": {
@@ -1978,7 +1979,6 @@
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
 			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -5715,6 +5715,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/qs": {
 			"version": "6.9.18",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -5728,6 +5734,25 @@
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.23",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
+			}
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -6644,6 +6669,39 @@
 				"@playwright/test": ">=1"
 			}
 		},
+		"node_modules/@wordpress/element": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.27.0.tgz",
+			"integrity": "sha512-gHk4B0J0f7bEsDoUBdTm22vPQwmEWLZxyaojgRyx1ncE2IyktfmubD/q2NIcMEKh7p+Jq3ZUwzPcpchpvkH2mA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^3.27.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/escape-html": {
+			"version": "3.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.27.0.tgz",
+			"integrity": "sha512-1LBB/xOFBUySSmVpd2nFwIZ8fVnP8dLNFl0wLprHVLtW6ZcdykO2ITY9bkaHu2lZ9HLRgHL7A/3R7MsJ1azYkg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/eslint-plugin": {
 			"version": "22.8.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.8.0.tgz",
@@ -6732,6 +6790,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/icons": {
+			"version": "10.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.27.0.tgz",
+			"integrity": "sha512-KeOz3aLtd7p+cA287gmGzpC9kIO1lxPBn/lDPkXfc8oz482XqNJKohdW/7ZMlEWx1uEcZUI+g3vfSA+gKDgjUQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/element": "^6.27.0",
+				"@wordpress/primitives": "^4.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
@@ -6831,6 +6904,24 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/primitives": {
+			"version": "4.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.27.0.tgz",
+			"integrity": "sha512-ZIhpB4ZmZwMSsrELx4mzhRvxAoqgk8sSE3PaRt/ue4GXFoRRQgI3RVCwEdiNPcsQXId9lOQIhAJNDt5Wa0Fbgg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/element": "^6.27.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -8876,7 +8967,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
 			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pascal-case": "^3.1.2",
@@ -8972,7 +9062,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
 			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -9001,7 +9090,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
 			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"camel-case": "^4.1.2",
@@ -9268,6 +9356,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -9511,7 +9608,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
 			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -10214,6 +10310,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/csstype": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"license": "MIT"
+		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
@@ -10843,7 +10945,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
 			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -13670,7 +13771,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
 			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"capital-case": "^1.0.4",
@@ -14700,7 +14800,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -15785,7 +15884,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -16654,7 +16752,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -16667,7 +16764,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
 			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
@@ -17364,7 +17460,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
 			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lower-case": "^2.0.2",
@@ -18041,7 +18136,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
 			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dot-case": "^3.0.4",
@@ -18123,7 +18217,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
 			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -18134,7 +18227,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
 			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dot-case": "^3.0.4",
@@ -20560,7 +20652,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -20573,9 +20664,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -20807,7 +20896,6 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/regenerator-transform": {
@@ -21430,9 +21518,7 @@
 			"version": "0.23.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
 			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
@@ -21620,7 +21706,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
 			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -22130,7 +22215,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
 			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dot-case": "^3.0.4",
@@ -23988,7 +24072,6 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsutils": {
@@ -24357,7 +24440,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
 			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
@@ -24367,7 +24449,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
 			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
 		"coreBlockTemplatesDir": "../../../../../dev/templates"
 	},
 	"dependencies": {
+		"@dnd-kit/core": "^6.3.1",
+		"@dnd-kit/modifiers": "^9.0.0",
+		"@dnd-kit/sortable": "^10.0.0",
+		"@dnd-kit/utilities": "^3.2.2",
 		"@wordpress/icons": "^10.23.0",
 		"imagesloaded": "^5.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
 		"@wordpress/icons": "^10.23.0",
-		"imagesloaded": "^5.0.0",
-		"delegate": "^3.2.0"
+		"delegate": "^3.2.0",
+		"imagesloaded": "^5.0.0"
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
 		"coreThemeBlocksDir": "./wp-content/themes/core/blocks",
 		"coreBlockTemplatesDir": "../../../../../dev/templates"
 	},
+	"dependencies": {
+		"@wordpress/icons": "^10.23.0",
+		"imagesloaded": "^5.0.0"
+	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
 		"@wordpress/create-block": "^4.65.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 	},
 	"dependencies": {
 		"@dnd-kit/core": "^6.3.1",
-		"@dnd-kit/modifiers": "^9.0.0",
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
 		"@wordpress/icons": "^10.23.0",

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -41,6 +41,7 @@ class Blocks_Definer implements Definer_Interface {
 		return [
 			self::TYPES           => DI\add( [
 				'tribe/copyright',
+				'tribe/logo-marquee',
 				'tribe/post-card',
 				'tribe/search-card',
 				'tribe/terms',

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/block.json
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/block.json
@@ -1,0 +1,49 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/logo-marquee",
+	"version": "0.1.0",
+	"title": "Logo Marquee",
+	"category": "theme",
+	"description": "Creates side-scrolling gallery of logos.",
+	"icon": "slides",
+	"attributes": {
+		"images": {
+			"type": "array",
+			"default": [],
+			"source": "query",
+			"selector": ".gallery-item",
+			"query": {
+				"url": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "src"
+				},
+				"id": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "data-id"
+				},
+				"alt": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "alt",
+					"default": ""
+				}
+			}
+		}
+	},
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"align": [ "wide", "full" ]
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
+}

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/edit.js
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/edit.js
@@ -1,0 +1,181 @@
+/**
+ * WordPress Dependencies
+ */
+
+import {
+	useBlockProps,
+	MediaPlaceholder,
+	BlockControls,
+	MediaReplaceFlow,
+} from '@wordpress/block-editor';
+import { Button, ToolbarGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { trash } from '@wordpress/icons';
+import './editor.pcss';
+
+export default function Edit( { attributes, setAttributes, isSelected } ) {
+	const { images } = attributes;
+	const blockProps = useBlockProps();
+
+	// Fetch media details for each image
+	// eslint-disable-next-line no-unused-vars
+	const imageData = useSelect(
+		( select ) => {
+			const { getMedia } = select( coreStore );
+			return images.map( ( img ) => {
+				if ( ! img.id ) {
+					return null;
+				}
+				const media = getMedia( img.id );
+				if ( ! media ) {
+					return null;
+				}
+				return {
+					id: img.id,
+					url: img.url,
+					alt: img.alt || media.alt_text,
+					title: media.title?.raw || '',
+				};
+			} );
+		},
+		[ images ]
+	);
+
+	// Handle selection of new media items
+	const onSelectImages = ( newImages ) => {
+		setAttributes( {
+			images: newImages.map( ( image ) => ( {
+				id: image.id,
+				url: image.url || image.source_url,
+				alt: image.alt || image.alt_text || '',
+			} ) ),
+		} );
+	};
+
+	// Handle removing an image
+	const removeImage = ( index ) => {
+		const newImages = [ ...images ];
+		newImages.splice( index, 1 );
+		setAttributes( { images: newImages } );
+	};
+
+	// Basic image styles
+	const imageStyle = {
+		maxWidth: '200px',
+		height: 'auto',
+	};
+
+	return (
+		<>
+			<BlockControls>
+				{ images.length > 0 && (
+					<ToolbarGroup>
+						<MediaReplaceFlow
+							mediaIds={ images.map( ( img ) => img.id ) }
+							allowedTypes={ [ 'image' ] }
+							accept="image/*"
+							multiple
+							onSelect={ onSelectImages }
+						/>
+					</ToolbarGroup>
+				) }
+			</BlockControls>
+			<div { ...blockProps }>
+				{ images.length === 0 ? (
+					<MediaPlaceholder
+						icon="format-gallery"
+						labels={ {
+							title: __( 'Logo Marquee' ),
+							instructions: __(
+								'Drag images, upload new ones or select files from your library.'
+							),
+						} }
+						onSelect={ onSelectImages }
+						accept="image/*"
+						allowedTypes={ [ 'image' ] }
+						multiple
+					/>
+				) : (
+					<div className="logo-list">
+						{ images.map( ( img, index ) => (
+							<div key={ index } className="gallery-item">
+								<div style={ { position: 'relative' } }>
+									<img
+										src={ img.url }
+										alt={ img.alt }
+										data-id={ img.id }
+										style={ imageStyle }
+									/>
+									{ isSelected && (
+										<Button
+											className="remove-image-button"
+											icon={ trash }
+											onClick={ () =>
+												removeImage( index )
+											}
+											style={ {
+												position: 'absolute',
+												top: '5px',
+												right: '5px',
+												backgroundColor:
+													'rgba(0,0,0,0.7)',
+												color: 'white',
+												padding: '2px',
+											} }
+										/>
+									) }
+								</div>
+							</div>
+						) ) }
+						{ isSelected && (
+							<div
+								className="logo-list-add-item"
+								style={ {
+									border: '1px dashed #ddd',
+									display: 'flex',
+									justifyContent: 'center',
+									alignItems: 'center',
+									width: '200px',
+									height: '200px',
+								} }
+							>
+								<MediaPlaceholder
+									icon="plus"
+									labels={ {
+										title: __( 'Add to gallery' ),
+										instructions: '',
+									} }
+									onSelect={ ( newImages ) => {
+										setAttributes( {
+											images: [
+												...images,
+												...newImages.map(
+													( image ) => ( {
+														id: image.id,
+														url:
+															image.url ||
+															image.source_url,
+														alt:
+															image.alt ||
+															image.alt_text ||
+															'',
+													} )
+												),
+											],
+										} );
+									} }
+									accept="image/*"
+									allowedTypes={ [ 'image' ] }
+									multiple
+									value={ {} }
+								/>
+							</div>
+						) }
+					</div>
+				) }
+			</div>
+		</>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/edit.js
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/edit.js
@@ -9,6 +9,80 @@ import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import './editor.pcss';
 
+import {
+	DndContext,
+	closestCenter,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import { SortableContext, useSortable, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useCallback } from '@wordpress/element';
+
+// Sortable item component
+const SortableImage = ( {
+	id,
+	img,
+	index,
+	isSelected,
+	removeImage,
+	imageStyle,
+} ) => {
+	const { attributes, listeners, setNodeRef, transform, transition } =
+		useSortable( { id } );
+
+	const style = {
+		transform: CSS.Transform.toString( transform ),
+		transition,
+		cursor: 'move',
+		position: 'relative',
+	};
+
+	return (
+		<div
+			ref={ setNodeRef }
+			{ ...attributes }
+			style={ style }
+			className="gallery-item"
+		>
+			<div
+				{ ...attributes }
+				{ ...listeners }
+				style={ {
+					cursor: 'grab',
+				} }
+				aria-label="Drag to reorder"
+			>
+				<img
+					src={ img.url }
+					alt={ img.alt }
+					data-id={ img.id }
+					style={ imageStyle }
+				/>
+			</div>
+			{ isSelected && (
+				<Button
+					className="remove-image-button"
+					icon={ trash }
+					aria-label={ __( 'Remove image' ) }
+					onClick={ () => removeImage( index ) }
+					style={ {
+						position: 'absolute',
+						top: '-15px',
+						right: '-30px',
+						backgroundColor: 'rgba(0,0,0,0.7)',
+						color: 'white',
+						padding: '0px',
+						minWidth: '0',
+						height: 'auto',
+					} }
+				/>
+			) }
+		</div>
+	);
+};
+
 export default function Edit( { attributes, setAttributes, isSelected } ) {
 	const { images } = attributes;
 	const blockProps = useBlockProps();
@@ -31,11 +105,32 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 		setAttributes( { images: newImages } );
 	};
 
+	// Handle drag-and-drop sort event
+	const handleDragEnd = useCallback(
+		( event ) => {
+			const { active, over } = event;
+			if ( active.id !== over?.id ) {
+				const oldIndex = images.findIndex(
+					( img ) => img.id === active.id
+				);
+				const newIndex = images.findIndex(
+					( img ) => img.id === over.id
+				);
+				setAttributes( {
+					images: arrayMove( images, oldIndex, newIndex ),
+				} );
+			}
+		},
+		[ images, setAttributes ]
+	);
+
 	// Basic image styles
 	const imageStyle = {
 		maxWidth: '200px',
 		height: 'auto',
 	};
+
+	const sensors = useSensors( useSensor( PointerSensor ) );
 
 	return (
 		<>
@@ -68,82 +163,74 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 						multiple
 					/>
 				) : (
-					<div className="logo-list">
-						{ images.map( ( img, index ) => (
-							<div key={ index } className="gallery-item">
-								<div style={ { position: 'relative' } }>
-									<img
-										src={ img.url }
-										alt={ img.alt }
-										data-id={ img.id }
-										style={ imageStyle }
+					<DndContext
+						sensors={ sensors }
+						collisionDetection={ closestCenter }
+						onDragEnd={ handleDragEnd }
+					>
+						<SortableContext
+							items={ images.map( ( img ) => img.id ) }
+						>
+							<div className="logo-list">
+								{ images.map( ( img, index ) => (
+									<SortableImage
+										key={ img.id }
+										id={ img.id }
+										img={ img }
+										index={ index }
+										isSelected={ isSelected }
+										removeImage={ removeImage }
+										imageStyle={ imageStyle }
 									/>
-									{ isSelected && (
-										<Button
-											className="remove-image-button"
-											icon={ trash }
-											onClick={ () =>
-												removeImage( index )
-											}
-											style={ {
-												position: 'absolute',
-												top: '5px',
-												right: '5px',
-												backgroundColor:
-													'rgba(0,0,0,0.7)',
-												color: 'white',
-												padding: '2px',
+								) ) }
+								{ isSelected && (
+									<div
+										className="logo-list-add-item"
+										style={ {
+											display: 'flex',
+											justifyContent: 'center',
+											alignItems: 'center',
+											width: '200px',
+											height: '160px',
+											padding: '0 25px',
+											overflow: 'hidden',
+										} }
+									>
+										<MediaPlaceholder
+											icon="plus"
+											labels={ {
+												title: __( 'Add to gallery' ),
+												instructions: '',
 											} }
+											onSelect={ ( newImages ) => {
+												setAttributes( {
+													images: [
+														...images,
+														...newImages.map(
+															( image ) => ( {
+																id: image.id,
+																url:
+																	image.url ||
+																	image.source_url,
+																alt:
+																	image.alt ||
+																	image.alt_text ||
+																	'',
+															} )
+														),
+													],
+												} );
+											} }
+											accept="image/*"
+											allowedTypes={ [ 'image' ] }
+											multiple
+											value={ {} }
 										/>
-									) }
-								</div>
+									</div>
+								) }
 							</div>
-						) ) }
-						{ isSelected && (
-							<div
-								className="logo-list-add-item"
-								style={ {
-									border: '1px dashed #ddd',
-									display: 'flex',
-									justifyContent: 'center',
-									alignItems: 'center',
-									width: '200px',
-									height: '200px',
-								} }
-							>
-								<MediaPlaceholder
-									icon="plus"
-									labels={ {
-										title: __( 'Add to gallery' ),
-										instructions: '',
-									} }
-									onSelect={ ( newImages ) => {
-										setAttributes( {
-											images: [
-												...images,
-												...newImages.map(
-													( image ) => ( {
-														id: image.id,
-														url:
-															image.url ||
-															image.source_url,
-														alt:
-															image.alt ||
-															image.alt_text ||
-															'',
-													} )
-												),
-											],
-										} );
-									} }
-									accept="image/*"
-									allowedTypes={ [ 'image' ] }
-									multiple
-									value={ {} }
-								/>
-							</div>
-						) }
-					</div>
+						</SortableContext>
+					</DndContext>
 				) }
 			</div>
 		</>

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/edit.js
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/edit.js
@@ -1,7 +1,3 @@
-/**
- * WordPress Dependencies
- */
-
 import {
 	useBlockProps,
 	MediaPlaceholder,
@@ -10,38 +6,12 @@ import {
 } from '@wordpress/block-editor';
 import { Button, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { trash } from '@wordpress/icons';
 import './editor.pcss';
 
 export default function Edit( { attributes, setAttributes, isSelected } ) {
 	const { images } = attributes;
 	const blockProps = useBlockProps();
-
-	// Fetch media details for each image
-	// eslint-disable-next-line no-unused-vars
-	const imageData = useSelect(
-		( select ) => {
-			const { getMedia } = select( coreStore );
-			return images.map( ( img ) => {
-				if ( ! img.id ) {
-					return null;
-				}
-				const media = getMedia( img.id );
-				if ( ! media ) {
-					return null;
-				}
-				return {
-					id: img.id,
-					url: img.url,
-					alt: img.alt || media.alt_text,
-					title: media.title?.raw || '',
-				};
-			} );
-		},
-		[ images ]
-	);
 
 	// Handle selection of new media items
 	const onSelectImages = ( newImages ) => {

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/editor.pcss
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/editor.pcss
@@ -1,0 +1,5 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/editor.pcss
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/editor.pcss
@@ -3,3 +3,28 @@
  *
  * Replace them with your own styles or remove the file completely.
  */
+
+.wp-block-tribe-logo-marquee {
+
+	/* Display logos in a grid layout when the block is selected in the editor */
+	&.is-selected {
+
+		.logo-list {
+			display: flex;
+			flex-flow: row wrap;
+			max-width: 100%;
+			gap: 50px 0;
+			justify-content: space-evenly;
+		}
+
+		.gallery-item {
+			width: 150px !important;
+			height: 50px;
+
+			img {
+				width: 100%;
+				height: auto;
+			}
+		}
+	}
+}

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/index.js
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/index.js
@@ -1,0 +1,34 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import './style.pcss';
+
+import Edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	icon: (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M4 15v-3H2V2h12v3h2v3h2v10H6v-3H4zm7-12c-1.1 0-2 .9-2 2h4a2 2 0 0 0-2-2zm-7 8V6H3v5h1zm7-3h4a2 2 0 1 0-4 0zm-5 6V9H5v5h1zm9-1a2 2 0 1 0 .001-3.999A2 2 0 0 0 15 13zm2 4v-2c-5 0-5-3-10-3v5h10z"
+				fill="black"
+			></path>
+		</svg>
+	),
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} );

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/save.js
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/save.js
@@ -1,0 +1,24 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function save( props ) {
+	const {
+		attributes: { images },
+	} = props;
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
+			<div className="logo-list">
+				{ images.map( ( img, index ) => (
+					<div key={ index } className="gallery-item">
+						<img
+							src={ img.url }
+							alt={ img.alt }
+							data-id={ img.id }
+						/>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
@@ -21,7 +21,7 @@
 		flex-wrap: nowrap;
 		flex-shrink: 0;
 		align-items: center;
-		gap: var(--spacer-60);
+		gap: 0;
 		width: max-content;
 		max-width: none;
 		will-change: transform;
@@ -35,6 +35,15 @@
 		}
 	}
 
+	/* Display logos in a grid layout when the block is selected in the editor */
+	&.is-selected .logo-list {
+		display: flex;
+		flex-flow: row wrap;
+		max-width: 100%;
+		gap: 30px 0;
+		justify-content: space-evenly;
+	}
+
 	/* handle gallery block image wrapper */
 	.gallery-item {
 		display: flex !important; /* override gallery block defaults */
@@ -42,7 +51,7 @@
 		justify-content: center;
 		flex: 0 0 auto;
 		width: auto !important; /* override gallery block defaults */
-		margin: 0 !important; /* override gallery block defaults */
+		margin: 0 var(--spacer-30) !important; /* override gallery block defaults */
 
 		/* prevent Safari flashing / eating */
 		-webkit-transform: translate3d(0, 0, 0);

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
@@ -54,29 +54,4 @@
 			max-height: 64px;
 		}
 	}
-
-
-
-	/* Display logos in a grid layout when the block is selected in the editor */
-	&.is-selected {
-
-		.logo-list {
-			display: flex;
-			flex-flow: row wrap;
-			max-width: 100%;
-			gap: 50px 0;
-			justify-content: space-evenly;
-		}
-
-		.gallery-item {
-			width: 150px !important;
-			height: 50px;
-
-			img {
-				width: 100%;
-				height: auto;
-			}
-		}
-
-	}
 }

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
@@ -1,0 +1,55 @@
+/**
+ * Styles specific to this block
+ */
+@keyframes marquee-scroll-x {
+
+	0% {
+		transform: translateX(0);
+	}
+
+	100% {
+		transform: translateX(-50%);
+	}
+}
+
+.wp-block-tribe-logo-marquee {
+	overflow-x: hidden; /* prevent horizontal scroll */
+
+	.logo-list {
+		padding: var(--spacer-50) 0;
+		display: inline-flex;
+		flex-wrap: nowrap;
+		flex-shrink: 0;
+		align-items: center;
+		gap: var(--spacer-60);
+		width: max-content;
+		max-width: none;
+		will-change: transform;
+		transform: translateX(0);
+
+		/* prevent Safari flashing / eating */
+		-webkit-backface-visibility: hidden;
+
+		@media (prefers-reduced-motion: reduce) {
+			animation-play-state: paused;
+		}
+	}
+
+	/* handle gallery block image wrapper */
+	.gallery-item {
+		display: flex !important; /* override gallery block defaults */
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		width: auto !important; /* override gallery block defaults */
+		margin: 0 !important; /* override gallery block defaults */
+
+		/* prevent Safari flashing / eating */
+		-webkit-transform: translate3d(0, 0, 0);
+
+		& img {
+			width: auto;
+			max-height: 64px;
+		}
+	}
+}

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/style.pcss
@@ -35,23 +35,16 @@
 		}
 	}
 
-	/* Display logos in a grid layout when the block is selected in the editor */
-	&.is-selected .logo-list {
-		display: flex;
-		flex-flow: row wrap;
-		max-width: 100%;
-		gap: 30px 0;
-		justify-content: space-evenly;
-	}
-
 	/* handle gallery block image wrapper */
 	.gallery-item {
-		display: flex !important; /* override gallery block defaults */
+		display: flex !important;
 		align-items: center;
 		justify-content: center;
 		flex: 0 0 auto;
-		width: auto !important; /* override gallery block defaults */
-		margin: 0 var(--spacer-30) !important; /* override gallery block defaults */
+		width: auto !important;
+		margin: 0 var(--spacer-30) !important;
+
+		/* transform: scale(1) !important; */
 
 		/* prevent Safari flashing / eating */
 		-webkit-transform: translate3d(0, 0, 0);
@@ -60,5 +53,30 @@
 			width: auto;
 			max-height: 64px;
 		}
+	}
+
+
+
+	/* Display logos in a grid layout when the block is selected in the editor */
+	&.is-selected {
+
+		.logo-list {
+			display: flex;
+			flex-flow: row wrap;
+			max-width: 100%;
+			gap: 50px 0;
+			justify-content: space-evenly;
+		}
+
+		.gallery-item {
+			width: 150px !important;
+			height: 50px;
+
+			img {
+				width: 100%;
+				height: auto;
+			}
+		}
+
 	}
 }

--- a/wp-content/themes/core/blocks/tribe/logo-marquee/view.js
+++ b/wp-content/themes/core/blocks/tribe/logo-marquee/view.js
@@ -1,0 +1,101 @@
+/**
+ * Scripts specific to this block
+ */
+
+import imagesLoaded from 'imagesloaded';
+
+const el = {
+	marquees: document.querySelectorAll(
+		'.wp-block-tribe-logo-marquee .logo-list'
+	),
+};
+
+const state = {
+	rate: 150,
+	clonesCreated: false,
+};
+
+/**
+ * @function setAnimationProperties
+ *
+ * @description set animation properties for the marquee
+ *
+ * @param {*} marquee
+ */
+const setAnimationProperties = ( marquee ) => {
+	const wrapperWidth = marquee.offsetWidth;
+	const duration = wrapperWidth / state.rate;
+
+	marquee.style.setProperty( '--animation-duration', `${ duration }s` );
+	marquee.style.setProperty(
+		'animation',
+		'marquee-scroll-x var(--animation-duration) linear infinite'
+	);
+};
+
+/**
+ * @function createClones
+ *
+ * @description creates cloned elements and hides them from screen readers
+ *
+ * @param {*} wrapper
+ */
+const createClones = ( wrapper ) => {
+	const elements = wrapper.querySelectorAll( '.gallery-item:not(.cloned)' );
+
+	if ( elements ) {
+		elements.forEach( ( element ) => {
+			const clone = element.cloneNode( true );
+			clone.setAttribute( 'aria-hidden', true );
+			clone.classList.add( 'cloned' );
+
+			wrapper.append( clone );
+		} );
+	}
+};
+
+/**
+ * @function checkWrapperWidth
+ *
+ * @description determines if we need to add more elements to the wrapper to fill the screen by checking the max-content wrapper against the window width
+ *
+ * @param {*} marquee
+ */
+const checkWrapperWidth = ( marquee ) => {
+	// we need at least 2 "widths" of elements to create the effect properly
+	if ( marquee.getBoundingClientRect().width < window.innerWidth * 2 ) {
+		state.clonesCreated = true;
+
+		createClones( marquee );
+
+		checkWrapperWidth( marquee );
+	}
+	// on mobile, it's possible for the logos to be wide enough to take up 2 widths without clones being created
+	else if (
+		marquee.getBoundingClientRect().width >= window.innerWidth * 2 &&
+		! state.clonesCreated
+	) {
+		state.clonesCreated = true;
+	}
+};
+
+/**
+ * @function init
+ *
+ * @description loops through all logo farm blocks to initialize the elements
+ */
+const init = () => {
+	if ( ! el.marquees ) {
+		return;
+	}
+
+	el.marquees.forEach( ( marquee ) => {
+		// use images loaded to detemine when we should initalize the script
+		imagesLoaded( marquee, () => {
+			checkWrapperWidth( marquee );
+			setAnimationProperties( marquee );
+		} );
+	} );
+};
+
+init();


### PR DESCRIPTION
## What does this do/fix?

Import the Logo Marquee block created by @tylermachado into 🫎.

This PR includes two enhancements to the original block:
- Updates the block to display all logos in the editor when selected (uses a grid layout for easier editing).
- Adds drag-and-drop functionality to reorder logos directly in the editor using [dnd-kit](https://docs.dndkit.com/).

It adds two dependencies:
```
"dependencies": {
	"@dnd-kit/core": "^6.3.1",
	"@dnd-kit/sortable": "^10.0.0",
	"@dnd-kit/utilities": "^3.2.2",
	"@wordpress/icons": "^10.23.0",
	"imagesloaded": "^5.0.0"
},
```

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-248)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/c6a91b07ba00496785e6a53333d10de7?sid=bca0c803-27fc-4fb3-9d71-c027b4748b47)
