### PR TITLE
[MOOSE-257] FE Linting Pre-Commit Hook

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -15,5 +15,5 @@ namespace PHPSTORM_META {
     override( \DI\Container::make( 0 ), map( [
         '' => '@',
     ] ) );
-    
+
 }

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -15,4 +15,5 @@ namespace PHPSTORM_META {
     override( \DI\Container::make( 0 ), map( [
         '' => '@',
     ] ) );
+    
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the
 item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2025.08]
+
+- Updated: pre-commit hooks now no longer run if the commit does not include files related to the hook. Pre-commit hooks now also include FE linting.
+
 ## [2025.07]
 - Updated: 404 & Search templates have been updated to Moose 2.0 design standards.
 - Fixed: Issue with editor pattern / template previews (still using `iframe` elements) displaying at the wrong width.

--- a/browsersync.config.js
+++ b/browsersync.config.js
@@ -20,7 +20,6 @@ function moduleExists( name ) {
 	try {
 		return require.resolve( name );
 	} catch ( e ) {
-
 		console.warn(
 			'Warning: local-config.json is missing. Did you create one?\n'
 		);

--- a/browsersync.config.js
+++ b/browsersync.config.js
@@ -20,6 +20,7 @@ function moduleExists( name ) {
 	try {
 		return require.resolve( name );
 	} catch ( e ) {
+
 		console.warn(
 			'Warning: local-config.json is missing. Did you create one?\n'
 		);

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ skip_output:
   - summary
 
 # code linting
-pre-commit:
+pre-push:
   parallel: true
   jobs:
     - name: phpcs

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,14 +16,17 @@ pre-commit:
       run: composer run phpcs
     phpstan:
       run: composer run phpstan
-    lintcss:
-      run: npm run lint:css
     lintjs:
       run: npm run lint:js
     lintconfigs:
       run: npm run lint:configs
     lintpkgjson:
       run: npm run lint:pkg-json
+  jobs:
+    - name: lintcss
+      run: npm run lint:css:fix
+      stage_fixed: true
+
 
 # prefix with jira ticket
 prepare-commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,12 +11,18 @@ skip_output:
 # code linting
 pre-commit:
   parallel: true
-  commands:
-    phpstan:
-      run: composer run phpstan
   jobs:
     - name: phpcs
       run: ./vendor/bin/phpcs -- {staged_files}
+      glob:
+        - ".phpstorm.meta.php"
+        - "local-config-sample.php"
+        - "wp-config.php"
+        - "wp-config-environment.php"
+        - "wp-content/themes/core/*.php"
+        - "wp-content/plugins/core/*.php"
+    - name: phpstan
+      run: ./vendor/bin/phpstan analyse --memory-limit=-1
       glob:
         - "wp-content/themes/core/*.php"
         - "wp-content/plugins/core/*.php"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,6 +18,7 @@ pre-commit:
     - name: phpcs
       run: ./vendor/bin/phpcs -- {staged_files}
       glob:
+        - "./*.php"
         - "./wp-content/themes/core/*.php"
         - "./wp-content/themes/core/**/*.php"
         - "./wp-content/plugins/core/*.php"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
     - name: phpcs
       run: ./vendor/bin/phpcs -- {staged_files}
       glob:
-        - "./*.php"
+        - "*.php"
         - "wp-content/themes/core/*.php"
         - "wp-content/plugins/core/*.php"
     - name: lintcss

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@ skip_output:
   - success
   - summary
 
-# phpcs
+# code linting
 pre-commit:
   parallel: true
   commands:
@@ -16,6 +16,14 @@ pre-commit:
       run: composer run phpcs
     phpstan:
       run: composer run phpstan
+    lintcss:
+      run: npm run lint:css
+    lintjs:
+      run: npm run lint:js
+    lintconfigs:
+      run: npm run lint:configs
+    lintpkgjson:
+      run: npm run lint:pkg-json
 
 # prefix with jira ticket
 prepare-commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,7 +24,9 @@ pre-commit:
       run: npm run lint:pkg-json
   jobs:
     - name: lintcss
-      run: npm run lint:css:fix
+      run: wp-scripts lint-style {staged_files} --fix
+      glob:
+        - "\"$npm_package_config_coreThemeDir/**/*.pcss\""
       stage_fixed: true
 
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,21 +31,21 @@ pre-commit:
         - "wp-content/themes/core/*.php"
         - "wp-content/plugins/core/*.php"
     - name: lintcss
-      run: wp-scripts lint-style {staged_files}
+      run: ./node_modules/.bin/wp-scripts lint-style {staged_files}
       glob:
         - "wp-content/themes/core/*.pcss"
     - name: lintjs
-      run: wp-scripts lint-js {staged_files}
+      run: ./node_modules/.bin/wp-scripts lint-js {staged_files}
       glob:
         - "wp-content/themes/core/*.js"
     - name: lintconfigs
-      run: wp-scripts lint-js {staged_files}
+      run: ./node_modules/.bin/wp-scripts lint-js {staged_files}
       glob:
         - "browsersync.config.js"
         - "postcss.config.js"
         - "webpack.config.js"
     - name: lintpkgjson
-      run: wp-scripts lint-pkg-json {staged_files}
+      run: ./node_modules/.bin/wp-scripts lint-pkg-json {staged_files}
       glob:
         - "package.json"
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,11 +24,11 @@ pre-commit:
     - name: lintcss
       run: wp-scripts lint-style {staged_files}
       glob:
-        - "$npm_package_config_coreThemeDir/*.pcss"
+        - "wp-content/themes/core/*.pcss"
     - name: lintjs
       run: wp-scripts lint-js {staged_files}
       glob:
-        - "$npm_package_config_coreThemeDir/*.js"
+        - "wp-content/themes/core/*.js"
     - name: lintconfigs
       run: wp-scripts lint-js {staged_files}
       glob:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,22 +12,29 @@ skip_output:
 pre-commit:
   parallel: true
   commands:
-    phpcs:
-      run: composer run phpcs
     phpstan:
       run: composer run phpstan
-    lintjs:
-      run: npm run lint:js
-    lintconfigs:
-      run: npm run lint:configs
-    lintpkgjson:
-      run: npm run lint:pkg-json
   jobs:
-    - name: lintcss
-      run: wp-scripts lint-style {staged_files} --fix
+    - name: phpcs
+      run: ./vendor/bin/phpcs -- {staged_files}
       glob:
-        - "\"$npm_package_config_coreThemeDir/**/*.pcss\""
-      stage_fixed: true
+        - "*.php"
+    - name: lintcss
+      run: wp-scripts lint-style {staged_files}
+      glob:
+        - "$npm_package_config_coreThemeDir/**/*.pcss"
+    - name: lintjs
+      run: wp-scripts lint-js {staged_files}
+      glob:
+        - "$npm_package_config_coreThemeDir/**/*.js"
+    - name: lintconfigs
+      run: wp-scripts lint-js {staged_files}
+      glob:
+        - "./*.js"
+    - name: lintpkgjson
+      run: wp-scripts lint-pkg-json {staged_files}
+      glob:
+        - "./package.json"
 
 
 # prefix with jira ticket

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,10 @@ pre-commit:
     - name: phpstan
       run: ./vendor/bin/phpstan analyse --memory-limit=-1
       glob:
+        - ".phpstorm.meta.php"
+        - "local-config-sample.php"
+        - "wp-config.php"
+        - "wp-config-environment.php"
         - "wp-content/themes/core/*.php"
         - "wp-content/plugins/core/*.php"
     - name: lintcss
@@ -37,11 +41,13 @@ pre-commit:
     - name: lintconfigs
       run: wp-scripts lint-js {staged_files}
       glob:
-        - "./*.js"
+        - "browsersync.config.js"
+        - "postcss.config.js"
+        - "webpack.config.js"
     - name: lintpkgjson
       run: wp-scripts lint-pkg-json {staged_files}
       glob:
-        - "./package.json"
+        - "package.json"
 
 
 # prefix with jira ticket

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,18 +19,16 @@ pre-commit:
       run: ./vendor/bin/phpcs -- {staged_files}
       glob:
         - "./*.php"
-        - "./wp-content/themes/core/*.php"
-        - "./wp-content/themes/core/**/*.php"
-        - "./wp-content/plugins/core/*.php"
-        - "./wp-content/plugins/core/**/*.php"
+        - "wp-content/themes/core/*.php"
+        - "wp-content/plugins/core/*.php"
     - name: lintcss
       run: wp-scripts lint-style {staged_files}
       glob:
-        - "$npm_package_config_coreThemeDir/**/*.pcss"
+        - "$npm_package_config_coreThemeDir/*.pcss"
     - name: lintjs
       run: wp-scripts lint-js {staged_files}
       glob:
-        - "$npm_package_config_coreThemeDir/**/*.js"
+        - "$npm_package_config_coreThemeDir/*.js"
     - name: lintconfigs
       run: wp-scripts lint-js {staged_files}
       glob:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,6 @@ pre-commit:
     - name: phpcs
       run: ./vendor/bin/phpcs -- {staged_files}
       glob:
-        - "*.php"
         - "wp-content/themes/core/*.php"
         - "wp-content/plugins/core/*.php"
     - name: lintcss

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,10 @@ pre-commit:
     - name: phpcs
       run: ./vendor/bin/phpcs -- {staged_files}
       glob:
-        - "*.php"
+        - "./wp-content/themes/core/*.php"
+        - "./wp-content/themes/core/**/*.php"
+        - "./wp-content/plugins/core/*.php"
+        - "./wp-content/plugins/core/**/*.php"
     - name: lintcss
       run: wp-scripts lint-style {staged_files}
       glob:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,12 +8,12 @@
 	<arg name="colors" />
 
 	<!--  Update to the PHP version your production/local docker container runs on -->
-	<config name="testVersion" value="8.2" />
+	<config name="testVersion" value="8.3" />
 	<!-- php -r 'echo PHP_VERSION_ID;' -->
-	<config name="php_version" value="80205" />
+	<config name="php_version" value="80315" />
 
 	<!-- Fix WordPress's terrible typing breaking PHPCS -->
-	<config name="minimum_supported_wp_version" value="6.4" />
+	<config name="minimum_supported_wp_version" value="6.8" />
 
 	<!-- Ignore warnings, show progress of the run and show sniff names -->
 	<arg value="nps" />

--- a/wp-config.php
+++ b/wp-config.php
@@ -7,9 +7,11 @@ require __DIR__ . '/wp-config-environment.php';
 // but not integration tests
 
 foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
+
 	if ( ! defined( $dbvar ) ) {
 		define( $dbvar, tribe_getenv( $dbvar, '' ) );
 	}
+    
 }
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wp-config.php
+++ b/wp-config.php
@@ -17,7 +17,7 @@ foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
-
+echo 'hi';
 
 // Bootstrap WordPress
 require_once ABSPATH . 'wp-settings.php';

--- a/wp-config.php
+++ b/wp-config.php
@@ -11,7 +11,7 @@ foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
 	if ( ! defined( $dbvar ) ) {
 		define( $dbvar, tribe_getenv( $dbvar, '' ) );
 	}
-    
+
 }
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wp-config.php
+++ b/wp-config.php
@@ -15,7 +15,6 @@ foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
 }
 
 if ( ! defined( 'ABSPATH' ) ) {
-    var_dump('hi');
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -12,12 +12,9 @@ foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
 	}
 }
 
-
-
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
-echo 'hi';
 
 // Bootstrap WordPress
 require_once ABSPATH . 'wp-settings.php';

--- a/wp-config.php
+++ b/wp-config.php
@@ -15,6 +15,7 @@ foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
 }
 
 if ( ! defined( 'ABSPATH' ) ) {
+    var_dump('hi');
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -18,5 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 
+
 // Bootstrap WordPress
 require_once ABSPATH . 'wp-settings.php';

--- a/wp-config.php
+++ b/wp-config.php
@@ -7,11 +7,9 @@ require __DIR__ . '/wp-config-environment.php';
 // but not integration tests
 
 foreach ( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $dbvar ) {
-
 	if ( ! defined( $dbvar ) ) {
 		define( $dbvar, tribe_getenv( $dbvar, '' ) );
 	}
-
 }
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## What does this do/fix?

- adds FE linting to pre-commit hook
    - this won't prevent some of the issues @spadilha was seeing with indenting and code editor specific things (maybe we need to look at our editor config?)
    - I specifically _chose_ to not run `--fix` on these FE hooks. I want developers to specifically see mistakes and actively correct them before committing their changes
- moved all lefthook commands to jobs to allow us to name and prevent them from running if there are no files in the commit with the types necessary to run the command
    - `phpstan` still runs on everything in the project but only runs if there are PHP changes in the commit
    - note here that any top-level file has to be called specifically as lefthook's `glob` doesn't recognize `./*.js` (etc...) as a valid selector
- updates PHP & WP versions for PHPCS 

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-257)
