### PR TITLE
[MOOSE-242]: Remove vertical margins from core/group

### DIFF
--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -195,27 +195,21 @@
 							"fontDisplay": "swap",
 							"fontStyle": "normal",
 							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/inter-tight-v7-latin-regular.woff2"
-							]
+							"src": ["file:./assets/fonts/inter-tight-v7-latin-regular.woff2"]
 						},
 						{
 							"fontFamily": "Inter",
 							"fontDisplay": "swap",
 							"fontStyle": "italic",
 							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/inter-tight-v7-latin-italic.woff2"
-							]
+							"src": ["file:./assets/fonts/inter-tight-v7-latin-italic.woff2"]
 						},
 						{
 							"fontFamily": "Inter",
 							"fontDisplay": "swap",
 							"fontStyle": "normal",
 							"fontWeight": "700",
-							"src": [
-								"file:./assets/fonts/inter-tight-v7-latin-700.woff2"
-							]
+							"src": ["file:./assets/fonts/inter-tight-v7-latin-700.woff2"]
 						},
 						{
 							"fontFamily": "Inter",
@@ -391,6 +385,14 @@
 						"typography": {
 							"textAlign": "left"
 						}
+					}
+				}
+			},
+			"core/group": {
+				"spacing": {
+					"margin": {
+						"top": "0",
+						"bottom": "0"
 					}
 				}
 			},


### PR DESCRIPTION
## What does this do/fix?

Sets the default top and bottom margin of the core/group block to zero in theme.json.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-204)
