### PR TITLE
[MOOSE-239]: Use svg-load and update dark-mode

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -61,7 +61,10 @@ const plugins = [
 	[
 		'postcss-inline-svg',
 		{
-			paths: [ `${ pkg.config.coreThemeDir }/assets/media/icons` ],
+			paths: [
+				`${ pkg.config.coreThemeDir }/assets/media/icons`,
+				`${ pkg.config.coreThemeDir }/blocks/tribe/rating-stars/icons`,
+			],
 		},
 	],
 	[

--- a/wp-content/themes/core/blocks/tribe/rating-stars/icons.pcss
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/icons.pcss
@@ -1,0 +1,26 @@
+
+@svg-load star-full url(icon-star-full.svg) {
+	fill: currentcolor;
+	stroke: currentcolor;
+}
+
+@svg-load star-half url(icon-star-half.svg) {
+
+	path:nth-child(1) {
+		stroke: currentcolor;
+	}
+
+	path:nth-child(2) {
+		fill: currentcolor;
+	}
+}
+
+@svg-load star-empty url(icon-star-empty.svg) {
+	stroke: currentcolor;
+}
+
+:root {
+	--icon-star-full: svg-inline(star-full);
+	--icon-star-half: svg-inline(star-half);
+	--icon-star-empty: svg-inline(star-empty);
+}

--- a/wp-content/themes/core/blocks/tribe/rating-stars/icons/icon-star-empty.svg
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/icons/icon-star-empty.svg
@@ -1,3 +1,3 @@
 <svg aria-hidden="true" width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M32 5.37201L40.652 22.9L60 25.712L46 39.358L49.304 58.628L32 49.534L14.696 58.628L18 39.358L4 25.712L23.348 22.9L32 5.37201Z" stroke="#ffc107" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/>
+<path d="M32 5.37201L40.652 22.9L60 25.712L46 39.358L49.304 58.628L32 49.534L14.696 58.628L18 39.358L4 25.712L23.348 22.9L32 5.37201Z" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/>
 </svg>

--- a/wp-content/themes/core/blocks/tribe/rating-stars/icons/icon-star-full.svg
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/icons/icon-star-full.svg
@@ -1,3 +1,3 @@
 <svg aria-hidden="true" width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M32 5.37201L40.652 22.9L60 25.712L46 39.358L49.304 58.628L32 49.534L14.696 58.628L18 39.358L4 25.712L23.348 22.9L32 5.37201Z" fill="#ffc107" stroke="#ffc107" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/>
+<path d="M32 5.37201L40.652 22.9L60 25.712L46 39.358L49.304 58.628L32 49.534L14.696 58.628L18 39.358L4 25.712L23.348 22.9L32 5.37201Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/>
 </svg>

--- a/wp-content/themes/core/blocks/tribe/rating-stars/icons/icon-star-half.svg
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/icons/icon-star-half.svg
@@ -1,4 +1,4 @@
 <svg aria-hidden="true" width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M32 5.37201L40.652 22.9L60 25.712L46 39.358L49.304 58.628L32 49.534L14.696 58.628L18 39.358L4 25.712L23.348 22.9L32 5.37201Z" stroke="#ffc107" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/>
-<path d="M15.696 57.628L32.5 49V5L23.348 22.9L5 25.712L19 39.358L15.696 57.628Z" fill="#ffc107"/>
+<path d="M32 5.37201L40.652 22.9L60 25.712L46 39.358L49.304 58.628L32 49.534L14.696 58.628L18 39.358L4 25.712L23.348 22.9L32 5.37201Z" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/>
+<path d="M15.696 57.628L32.5 49V5L23.348 22.9L5 25.712L19 39.358L15.696 57.628Z" fill="currentColor"/>
 </svg>

--- a/wp-content/themes/core/blocks/tribe/rating-stars/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/style.pcss
@@ -9,7 +9,7 @@
 
 @svg-load star-half url(icon-star-half.svg) {
 
-	path:nth-child(2) {
+	path:nth-child(1) {
 		stroke: currentcolor;
 	}
 

--- a/wp-content/themes/core/blocks/tribe/rating-stars/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/style.pcss
@@ -2,6 +2,32 @@
  * The following styles get applied both on the front and in the editor.
  */
 
+@svg-load star-full url(icon-star-full.svg) {
+	fill: currentcolor;
+	stroke: currentcolor;
+}
+
+@svg-load star-half url(icon-star-half.svg) {
+
+	path:nth-child(2) {
+		stroke: currentcolor;
+	}
+
+	path:nth-child(2) {
+		fill: currentcolor;
+	}
+}
+
+@svg-load star-empty url(icon-star-empty.svg) {
+	stroke: currentcolor;
+}
+
+:root {
+	--icon-star-full: svg-inline(star-full);
+	--icon-star-half: svg-inline(star-half);
+	--icon-star-empty: svg-inline(star-empty);
+}
+
 /* -----------------------------------------------------------------------
  * Rating Stars Block
  * ----------------------------------------------------------------------- */
@@ -13,23 +39,29 @@
 		width: var(--rating-stars--size, 200px);
 		max-width: 100%;
 
-		.rating-stars__star {
-			aspect-ratio: 1/1;
-			background-size: cover;
-			background-repeat: no-repeat;
-			display: inline-block;
-		}
-
 		.star--full {
-			background-image: url(./icons/icon-star-full.svg);
+			mask: var(--icon-star-full) center no-repeat;
 		}
 
 		.star--half {
-			background-image: url(./icons/icon-star-half.svg);
+			mask: var(--icon-star-half) center no-repeat;
 		}
 
 		.star--empty {
-			background-image: url(./icons/icon-star-empty.svg);
+			mask: var(--icon-star-empty) center no-repeat;
+		}
+
+		.rating-stars__star {
+			aspect-ratio: 1/1;
+			display: block;
+			mask-size: contain;
+			width: 100%;
+			height: 100%;
+			background-color: var(--color-text);
+
+			.is-style-dark & {
+				background-color: var(--color-white);
+			}
 		}
 	}
 }

--- a/wp-content/themes/core/blocks/tribe/rating-stars/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/rating-stars/style.pcss
@@ -1,32 +1,7 @@
 /**
- * The following styles get applied both on the front and in the editor.
+ * Import SVG icons
  */
-
-@svg-load star-full url(icon-star-full.svg) {
-	fill: currentcolor;
-	stroke: currentcolor;
-}
-
-@svg-load star-half url(icon-star-half.svg) {
-
-	path:nth-child(1) {
-		stroke: currentcolor;
-	}
-
-	path:nth-child(2) {
-		fill: currentcolor;
-	}
-}
-
-@svg-load star-empty url(icon-star-empty.svg) {
-	stroke: currentcolor;
-}
-
-:root {
-	--icon-star-full: svg-inline(star-full);
-	--icon-star-half: svg-inline(star-half);
-	--icon-star-empty: svg-inline(star-empty);
-}
+ @import "icons.pcss";
 
 /* -----------------------------------------------------------------------
  * Rating Stars Block


### PR DESCRIPTION
## What does this do/fix?


This pull request updates how SVG icons are loaded and styled for the Rating Stars block, improving maintainability and theme compatibility. The main changes include configuring PostCSS to support inline SVGs from the new icons directory, defining SVG icons as CSS variables, and refactoring the block’s styling to use CSS masks instead of background images.

**SVG Icon Loading and Configuration**
* Updated `postcss.config.js` to include the `blocks/tribe/rating-stars/icons` directory for inline SVG processing, enabling the use of custom star icons in the block styles.

**Block Styling Refactor**
* Defined SVG icons (`star-full`, `star-half`, `star-empty`) using `@svg-load` and set them as CSS variables for easy reference and theming.
* Refactored the `.star--full`, `.star--half`, and `.star--empty` classes to use CSS `mask` with the inline SVG variables instead of `background-image`, improving flexibility and color control.
* Updated `.rating-stars__star` styling to use block display, mask sizing, and dynamic background color, including support for dark style variants.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-239)
