### PR TITLE
[MOOSE-268]: adjust spacing for query loop

### DIFF
--- a/wp-content/themes/core/blocks/core/posttemplate/style.pcss
+++ b/wp-content/themes/core/blocks/core/posttemplate/style.pcss
@@ -19,7 +19,7 @@
  */
 .wp-block-post-content .wp-block-post-template.is-layout-grid {
 	--post-template-grid-template-columns: 1fr;
-	gap: var(--spacer-40);
+	gap: var(--spacer-50);
 	grid-template-columns: var(--post-template-grid-template-columns);
 
 	&.columns-2,


### PR DESCRIPTION
## What does this do/fix?


This pull request makes a minor adjustment to the grid layout spacing in the `posttemplate` block style. The gap between grid items is increased to improve visual spacing.

- Increased the grid gap from `var(--spacer-40)` to `var(--spacer-50)` in `.wp-block-post-content .wp-block-post-template.is-layout-grid` to provide more space between items.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-268)

