### PR TITLE
[MOOSE-269] Image Block Updates

### DIFF
--- a/wp-content/themes/core/styles/blocks/image/20-full.json
+++ b/wp-content/themes/core/styles/blocks/image/20-full.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "full",
+	"title": "Full",
+	"blockTypes": [ "core/image" ],
+	"styles": {
+		"border": {
+			"radius": "9999px"
+		}
+	}
+}

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -62,6 +62,13 @@
 					"fontSizes": []
 				}
 			},
+			"core/image": {
+				"border": {
+					"color": true,
+					"radius": true,
+					"width": true
+				}
+			},
 			"core/list": {
 				"typography": {
 					"fontFamilies": [],


### PR DESCRIPTION
## What does this do/fix?

This pull request introduces improved styling options for the `core/image` block in the WordPress theme. It adds support for customizable border properties and introduces a new full-width image style with a fully rounded border.

Styling enhancements for image blocks:

* Added support for border color, radius, and width customization to the `core/image` block in `theme.json`, allowing users to adjust these border properties directly in the editor.
* Introduced a new `20-full.json` style variation for the `core/image` block, named "Full", which applies a fully rounded border radius (`9999px`) to images for a pill/circle effect.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-269)

Screenshots/video:
- Full styled enabled / border settings displayed: http://p.tri.be/i/ndzEfX
