### PR TITLE
[MOOSE-24] Rename Tabs block

### DIFF
--- a/wp-content/themes/core/blocks/tribe/tab/block.json
+++ b/wp-content/themes/core/blocks/tribe/tab/block.json
@@ -3,9 +3,9 @@
 	"apiVersion": 3,
 	"name": "tribe/tab",
 	"version": "0.1.0",
-	"title": "Tab",
+	"title": "Horizontal Tab",
 	"category": "theme",
-	"description": "Child of Tabs block",
+	"description": "A child block of the Horizontal Tabs block",
 	"icon": "text-page",
 	"parent": [ "tribe/tabs" ],
 	"supports": {

--- a/wp-content/themes/core/blocks/tribe/tabs/block.json
+++ b/wp-content/themes/core/blocks/tribe/tabs/block.json
@@ -3,9 +3,9 @@
 	"apiVersion": 3,
 	"name": "tribe/tabs",
 	"version": "0.1.0",
-	"title": "Tabs",
+	"title": "Horizontal Tabs",
 	"category": "theme",
-	"description": "Allows creation of tabbed content",
+	"description": "Tab content displayed horizontally",
 	"icon": "slides",
 	"supports": {
 		"html": false,

--- a/wp-content/themes/core/blocks/tribe/tabs/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/tabs/style.pcss
@@ -43,6 +43,7 @@
 	}
 
 	&:hover,
+	&:focus-visible,
 	&[aria-selected="true"] {
 		color: var(--color-blue);
 

--- a/wp-content/themes/core/blocks/tribe/tabs/style.pcss
+++ b/wp-content/themes/core/blocks/tribe/tabs/style.pcss
@@ -42,6 +42,7 @@
 		color: var(--color-white);
 	}
 
+	&:hover,
 	&[aria-selected="true"] {
 		color: var(--color-blue);
 


### PR DESCRIPTION
## What does this do/fix?

This pull request updates the naming and descriptions of the tab-related blocks to clarify that they are specifically for horizontal tab layouts, and improves the tab styling for better user interaction. 

Block metadata improvements:

* Updated the `title` and `description` in `block.json` for both `tribe/tabs` and `tribe/tab` blocks to specify "Horizontal Tabs" and clarify their purpose and relationship.

> [!NOTE]
> I left the folder and block names unchanged to avoid breaking existing projects that already rely on them. Open to hearing thoughts from other devs on whether we should keep this approach or consider renaming.

Styling enhancements:

* Improved the tab styling in `style.pcss` so the hover style matches the active/selected style, providing consistent visual feedback.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-224)
