### PR TITLE
fix: resolve npm peer dependency conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5762,6 +5762,17 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -5773,6 +5784,19 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@eslint/js": {
@@ -5909,6 +5933,30 @@
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -6849,6 +6897,17 @@
 				}
 			}
 		},
+		"node_modules/@jest/reporters/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/@jest/reporters/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6886,6 +6945,19 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/semver": {
@@ -11756,9 +11828,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.24",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
-			"integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+			"version": "10.4.25",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.25.tgz",
+			"integrity": "sha512-haPdJifHzYbmnDxx0be44kvj89RWIe+1DZBUyM5BIsT/1bpI5pwK+v30cqz+EfxsxanHq8q2YUvy7LfdRXd/rQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -11777,7 +11849,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001766",
+				"caniuse-lite": "^1.0.30001774",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -13116,6 +13188,13 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
@@ -15205,6 +15284,17 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -15226,6 +15316,19 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
@@ -15452,6 +15555,30 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 			}
 		},
+		"node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/eslint-plugin-playwright": {
 			"version": "0.15.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
@@ -15545,6 +15672,17 @@
 				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
 			}
 		},
+		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/eslint-plugin-react/node_modules/doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -15556,6 +15694,19 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -15622,6 +15773,17 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
@@ -15710,6 +15872,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint/node_modules/p-locate": {
@@ -16403,6 +16578,17 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
+		"node_modules/flat-cache/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/flat-cache/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -16423,6 +16609,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/flat-cache/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/flat-cache/node_modules/rimraf": {
@@ -16880,6 +17079,18 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/global-modules": {
 			"version": "0.2.3",
@@ -17542,6 +17753,30 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/ignore-walk/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/ignore-walk/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/image-ssim": {
@@ -18730,6 +18965,17 @@
 				}
 			}
 		},
+		"node_modules/jest-config/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/jest-config/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -18750,6 +18996,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/jest-config/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/jest-dev-server": {
@@ -19286,6 +19545,17 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-runtime/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/jest-runtime/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -19306,6 +19576,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/jest-snapshot": {
@@ -20447,6 +20730,17 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/markdownlint-cli/node_modules/commander": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
@@ -20479,6 +20773,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/markdownlint-cli/node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -20500,6 +20807,19 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/minimatch": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/markdownlint-rule-helpers": {
@@ -20789,15 +21109,19 @@
 			"license": "ISC"
 		},
 		"node_modules/minimatch": {
-			"version": "5.1.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
-			"integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minimist": {
@@ -21251,6 +21575,17 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/npm-packlist/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/npm-packlist/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -21271,6 +21606,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm-packlist/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -21904,9 +22252,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
-			"integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.12.0.tgz",
+			"integrity": "sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -25235,6 +25583,17 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/resp-modifier/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/resp-modifier/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -25243,6 +25602,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
+			}
+		},
+		"node_modules/resp-modifier/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/resp-modifier/node_modules/ms": {
@@ -25289,6 +25661,29 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rimraf/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/rimraf/node_modules/glob": {
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -25306,6 +25701,22 @@
 			},
 			"bin": {
 				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+			"integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -27790,6 +28201,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/test-exclude/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -27810,6 +28232,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/test-exclude/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/text-decoder": {
@@ -28985,6 +29420,17 @@
 				}
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/connect-history-api-fallback": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -29015,6 +29461,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/rimraf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
-			"integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.0",
@@ -2075,14 +2075,14 @@
 			}
 		},
 		"node_modules/@cacheable/utils": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
-			"integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.4.tgz",
+			"integrity": "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.3.0",
-				"keyv": "^5.5.5"
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/utils/node_modules/keyv": {
@@ -2191,9 +2191,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.26",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
-			"integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+			"version": "1.0.28",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+			"integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2252,9 +2252,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-alpha-function": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-alpha-function/-/postcss-alpha-function-2.0.2.tgz",
-			"integrity": "sha512-EXdJC5fds0h1KqoioUBkcYPZvcNKR64jrGkbqlDNbMU3FP1MzLEr/QJR8bj/bu53TJFIgkc9WvKcpbwVqZ4WPg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-alpha-function/-/postcss-alpha-function-2.0.3.tgz",
+			"integrity": "sha512-8GqzD3JnfpKJSVxPIC0KadyAfB5VRzPZdv7XQ4zvK1q0ku+uHVUAS2N/IDavQkW40gkuUci64O0ea6QB/zgCSw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2268,7 +2268,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -2282,9 +2282,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-alpha-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2302,9 +2302,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-alpha-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2326,9 +2326,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-alpha-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2342,8 +2342,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -2461,9 +2461,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-5.0.1.tgz",
-			"integrity": "sha512-SNU4o63+oZpB7ufkTmj3FholvMtJwuyIWqTOVOxnZjNDFEg1hwdbnPjoytZVgKRQGkvkHdAS0uZWn0zH+ZwXCQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-5.0.2.tgz",
+			"integrity": "sha512-CjBdFemUFcAh3087MEJhZcO+QT1b8S75agysa1rU9TEC1YecznzwV+jpMxUc0JRBEV4ET2PjLssqmndR9IygeA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2477,7 +2477,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -2491,9 +2491,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function-display-p3-linear": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function-display-p3-linear/-/postcss-color-function-display-p3-linear-2.0.1.tgz",
-			"integrity": "sha512-blnzzMkMswoagp1u3JS1OiiTuQCW1F+lQEtlxu2BXhTUmEeKHhSgrrAceF7s4bwZOwKYbkxuw/FC9Ni/zxB7Xw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function-display-p3-linear/-/postcss-color-function-display-p3-linear-2.0.2.tgz",
+			"integrity": "sha512-TWUwSe1+2KdYGGWTx5LR4JQN07vKHAeSho+bGYRgow+9cs3dqgOqS1f/a1odiX30ESmZvwIudJ86wzeiDR6UGg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2507,7 +2507,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -2521,9 +2521,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function-display-p3-linear/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2541,9 +2541,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function-display-p3-linear/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2565,9 +2565,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function-display-p3-linear/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2581,8 +2581,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -2636,9 +2636,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2656,9 +2656,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2680,9 +2680,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2696,8 +2696,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -2751,9 +2751,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-function": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-4.0.1.tgz",
-			"integrity": "sha512-B9XBCd8cmHVwnc5YTn2YVXOlNMTNwuPIpJQ87665vaNdfNorVWz8JhAAv7Vq0v66TA6htE7+QW0OidL/QV0tiA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-4.0.2.tgz",
+			"integrity": "sha512-PFKQKswFqZrYKpajZsP4lhqjU/6+J5PTOWq1rKiFnniKsf4LgpGXrgHS/C6nn5Rc51LX0n4dWOWqY5ZN2i5IjA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2767,7 +2767,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -2781,9 +2781,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2801,9 +2801,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2825,9 +2825,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2841,8 +2841,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -2896,9 +2896,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-variadic-function-arguments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-2.0.1.tgz",
-			"integrity": "sha512-PV5nv9EHsEsvC5GlVqAHa1PznP/qZxFAIABImrkGJUbSoFUTwpnPch/dYSKw52CQ0aNnwCqMHoM29wDwmpVLqw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-2.0.2.tgz",
+			"integrity": "sha512-zEchsghpDH/6SytyjKu9TIPm4hiiWcur102cENl54cyIwTZsa+2MBJl/vtyALZ+uQ17h27L4waD+0Ow96sgZow==",
 			"dev": true,
 			"funding": [
 				{
@@ -2912,7 +2912,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -2926,9 +2926,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-variadic-function-arguments/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2946,9 +2946,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-variadic-function-arguments/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2970,9 +2970,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-color-mix-variadic-function-arguments/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2986,8 +2986,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -3113,9 +3113,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-contrast-color-function": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-contrast-color-function/-/postcss-contrast-color-function-3.0.1.tgz",
-			"integrity": "sha512-Zy2gyAPsUyoAUkmBjLbWcXJhglM+toBRpNegyJc/LTHpSpIbMKVmByGQ+VSw01E1Pov8Dk/fgEs9hd11xtGC8g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-contrast-color-function/-/postcss-contrast-color-function-3.0.2.tgz",
+			"integrity": "sha512-fwOz/m+ytFPz4aIph2foQS9nEDOdOjYcN5bgwbGR2jGUV8mYaeD/EaTVMHTRb/zqB65y2qNwmcFcE6VQty69Pw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3129,7 +3129,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -3143,9 +3143,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-contrast-color-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3163,9 +3163,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-contrast-color-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3187,9 +3187,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-contrast-color-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3203,8 +3203,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -3258,9 +3258,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-exponential-functions": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-3.0.0.tgz",
-			"integrity": "sha512-KCtnlZw1VrDCAbYxE44rUHONYAkjhh0/iS5T3L2K5OHuvoSEvxDjJO82pRwTmsRxVtSiC+syPjx2k2xsqHOM7w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-3.0.1.tgz",
+			"integrity": "sha512-WHJ52Uk0AVUIICEYRY9xFHJZAuq0ZVg0f8xzqUN2zRFrZvGgRPpFwxK7h9FWvqKIOueOwN6hnJD23A8FwsUiVw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3274,7 +3274,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0"
 			},
@@ -3286,9 +3286,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-exponential-functions/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3379,10 +3379,10 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/@csstools/postcss-gamut-mapping": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-3.0.1.tgz",
-			"integrity": "sha512-0S7D+gArVXsgRDxjoNv8g2QlaIi/SegqdlTMgVwowaPSyxaZsVnwrhShvmlpoLOVHmpJfHKGiXzn1Hc1BcZCzQ==",
+		"node_modules/@csstools/postcss-font-width-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-font-width-property/-/postcss-font-width-property-1.0.0.tgz",
+			"integrity": "sha512-AvmySApdijbjYQuXXh95tb7iVnqZBbJrv3oajO927ksE/mDmJBiszm+psW8orL2lRGR8j6ZU5Uv9/ou2Z5KRKA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3396,7 +3396,33 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/utilities": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4"
+			}
+		},
+		"node_modules/@csstools/postcss-gamut-mapping": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-3.0.2.tgz",
+			"integrity": "sha512-IrXAW3KQ3Sxm29C3/4mYQ/iA0Q5OH9YFOPQ2w24iIlXpD06A9MHvmQapP2vAGtQI3tlp2Xw5LIdm9F8khARfOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"dependencies": {
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0"
 			},
@@ -3408,9 +3434,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3428,9 +3454,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3452,9 +3478,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3468,8 +3494,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -3546,9 +3572,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gradients-interpolation-method": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-6.0.1.tgz",
-			"integrity": "sha512-Y5dxOstuUCdmU1tuEB/EgKxDw+/DAZes4gQeitb/H0S5khmjT24CfbVa/l2ZelNCEEq9KjxqO2cjwDV2vqj62w==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-6.0.2.tgz",
+			"integrity": "sha512-saQHvD1PD/zCdn+kxCWCcQOdXZBljr8L6BKlCLs0w8GXYfo3SHdWL1HZQ+I1hVCPlU+MJPJJbZJjG/jHRJSlAw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3562,7 +3588,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -3576,9 +3602,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3596,9 +3622,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3620,9 +3646,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3636,8 +3662,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -3691,9 +3717,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-hwb-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-5.0.1.tgz",
-			"integrity": "sha512-9f8TA/B8iEpzF0y4Z6qPVfP9nMp2ti10OFbtyDtoBz3+eK0KPV4CCCjTwYIpPRopLgctFZt7xqmOxA7JgAJEug==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-5.0.2.tgz",
+			"integrity": "sha512-ChR0+pKc/2cs900jakiv8dLrb69aez5P3T+g+wfJx1j6mreAe8orKTiMrVBk+DZvCRqpdOA2m8VoFms64A3Dew==",
 			"dev": true,
 			"funding": [
 				{
@@ -3707,7 +3733,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -3721,9 +3747,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3741,9 +3767,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3765,9 +3791,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3781,8 +3807,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -4165,9 +4191,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-media-minmax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
-			"integrity": "sha512-42szvyZ/oqG7NSvBQOGq1IaJaHR6mr/iXqqjW8/JuIajIHRs9HcJR5ExC4vbyCqk+fr7/DIOhm5ZrELBytLDsw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-3.0.1.tgz",
+			"integrity": "sha512-I+CrmZt23fyejMItpLQFOg9gPXkDBBDjTqRT0UxCTZlYZfGrzZn4z+2kbXLRwDfR59OK8zaf26M4kwYwG0e1MA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4181,7 +4207,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/media-query-list-parser": "^5.0.0"
@@ -4194,9 +4220,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-media-minmax/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4503,9 +4529,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-oklab-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-5.0.1.tgz",
-			"integrity": "sha512-Ql+X4zu29ITihxHKcCFEU84ww+Nkv44M2s0fT7Nv4iQYlQ4+liF6v9RL0ezeogeiLRNLLC6yh0ay1PHpmaNIgQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-5.0.2.tgz",
+			"integrity": "sha512-3d/Wcnp2uW6Io0Tajl0croeUo46gwOVQI9N32PjA/HVQo6z1iL7yp19Gp+6e5E5CDKGpW7U822MsDVo2XK1z0Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4519,7 +4545,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -4533,9 +4559,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4553,9 +4579,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4577,9 +4603,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4593,8 +4619,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -4767,9 +4793,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-random-function": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-3.0.0.tgz",
-			"integrity": "sha512-H/Zt5o9NAd8mowq3XRy8uU19wOEe8sbKyKOKxrzOdG0rz2maA4fLcXc9MQucdm3s4zMDfVJtCqvwrLP7lKWybA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-3.0.1.tgz",
+			"integrity": "sha512-SvKGfmj+WHfn4bWHaBYlkXDyU3SlA3fL8aaYZ8Op6M8tunNf3iV9uZyZZGWMCbDw0sGeoTmYZW9nmKN8Qi/ctg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4783,7 +4809,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0"
 			},
@@ -4795,9 +4821,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-random-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4862,9 +4888,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-relative-color-syntax": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-4.0.1.tgz",
-			"integrity": "sha512-zRLO9xMGtCCT0FTpTsaGI6cmdzJKbwWjg92AuczlSDuriEAPEJL+ZJ4jDyw51p23DfoAFgK8soB/LyoY1kFOLQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-4.0.2.tgz",
+			"integrity": "sha512-HaMN+qMURinllszbps2AhXKaLeibg/2VW6FriYDrqE58ji82+z2S3/eLloywVOY8BQCJ9lZMdy6TcRQNbn9u3w==",
 			"dev": true,
 			"funding": [
 				{
@@ -4878,7 +4904,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -4892,9 +4918,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4912,9 +4938,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4936,9 +4962,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4952,8 +4978,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -5047,9 +5073,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-sign-functions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-2.0.0.tgz",
-			"integrity": "sha512-32Bw7++8ToSLMEOSJUuxJsAJJdsIfgeD1dYPKRCk9/fTciVZ8MjkPXypwiXIo7xIJk0h5CJz6QUkDoc6dcAJ7Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-2.0.1.tgz",
+			"integrity": "sha512-C3br0qcHJkQ0qSGUBnDJHXQdO8XObnCpGwai5m1L2tv2nCjt0vRHG6A9aVCQHvh08OqHNM2ty1dYDNNXV99YAQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5063,7 +5089,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0"
 			},
@@ -5075,9 +5101,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-sign-functions/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5142,9 +5168,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-stepped-value-functions": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-5.0.0.tgz",
-			"integrity": "sha512-NueCSNbaq7QtAj6QwseMqOlM3C8nN2GWaPwd2Uw+IOYAbGvO/84BxUtNeZljeOmqJX61hwSNhLfwmgJXgY0W5A==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-5.0.1.tgz",
+			"integrity": "sha512-vZf7zPzRb7xIi2o5Z9q6wyeEAjoRCg74O2QvYxmQgxYO5V5cdBv4phgJDyOAOP3JHy4abQlm2YaEUS3gtGQo0g==",
 			"dev": true,
 			"funding": [
 				{
@@ -5158,7 +5184,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0"
 			},
@@ -5170,9 +5196,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-stepped-value-functions/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5353,9 +5379,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-text-decoration-shorthand": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-5.0.1.tgz",
-			"integrity": "sha512-yH9VyYE1LFLfyp6fYMLSUVON7vILzp1U2NkiCEIi7FM0M5thKd4XJJioD2a2a4t5sHwKesVaGyg89k2Hf1z0Sg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-5.0.3.tgz",
+			"integrity": "sha512-62fjggvIM1YYfDJPcErMUDkEZB6CByG8neTJqexnZe1hRBgCjD4dnXDLoCSSurjs1LzjBq6irFDpDaOvDZfrlw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5369,7 +5395,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
+				"@csstools/color-helpers": "^6.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -5380,9 +5406,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-text-decoration-shorthand/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5400,9 +5426,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-trigonometric-functions": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-5.0.0.tgz",
-			"integrity": "sha512-isjkD3l1MVjanGuaS7RIYP/9txZKbZ8eQPaUHoxEWmySm3k6KutSepzPINL6MXyyi0ZUijZcktA++/L66IK71A==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-5.0.1.tgz",
+			"integrity": "sha512-e8me32Mhl8JeBnxVJgsQUYpV4Md4KiyvpILpQlaY/eK1Gwdb04kasiTTswPQ5q7Z8+FppJZ2Z4d8HRfn6rjD3w==",
 			"dev": true,
 			"funding": [
 				{
@@ -5416,7 +5442,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0"
 			},
@@ -5428,9 +5454,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-trigonometric-functions/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5736,17 +5762,6 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -5758,19 +5773,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@eslint/js": {
@@ -5874,9 +5876,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@hapi/tlds": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
-			"integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+			"integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -5907,30 +5909,6 @@
 			},
 			"engines": {
 				"node": ">=10.10.0"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -6871,17 +6849,6 @@
 				}
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/@jest/reporters/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6921,23 +6888,10 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/@jest/reporters/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7435,9 +7389,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7679,9 +7633,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8142,14 +8096,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-			"integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.58.1"
+				"playwright": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -8251,9 +8205,9 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8372,9 +8326,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9053,9 +9007,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.31",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.31.tgz",
-			"integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
+			"version": "20.19.33",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+			"integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9129,9 +9083,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.27",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -9320,9 +9274,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9451,9 +9405,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9490,9 +9444,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -10018,9 +9972,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.39.0.tgz",
-			"integrity": "sha512-H5rheT+rrXuPb9+ey5LemC8g4i5uGVndpalboEQHaXVpLII9B283+ZmtQZy1We1RdIyVXD6MB2EtSXt8R4oKuw==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.40.0.tgz",
+			"integrity": "sha512-UzSwDaxsMarnlfFUmEWW2qvkJy4JupW49uH0JztFobCamQ5QCL71M75zIspIXffiZVjQMBWruR7/+5QTJklewA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10030,8 +9984,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.39.0",
-				"@wordpress/warning": "^3.39.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/warning": "^3.40.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -10073,9 +10027,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
-			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.16.0.tgz",
+			"integrity": "sha512-g8eZCTULM9rdQMTYfp3U+bHjT6wTtyuo8BFE2PCwJmH60Lp6P4qjnaez1PDW2M3yujCPwDdQBIR8tPXrTAlC/A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10084,9 +10038,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.39.0.tgz",
-			"integrity": "sha512-fHVG274KKjgAyF7ruvKe+H2JXKh3T7wh3jMrLYoIUx39Hr/LfjYbnsVqWaUDyRhx4nLnk0XIpBfGc+38TDuROQ==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.40.0.tgz",
+			"integrity": "sha512-aX44MD4Kcr4LZT1YWa3VkMUUJjNfAgt7UECs/qrNGM8tC3l4/2Z4zRkJfpK3AoaXusb1J8+r5ZXWJWhxYK1JMQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10095,14 +10049,14 @@
 			}
 		},
 		"node_modules/@wordpress/create-block": {
-			"version": "4.82.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.82.0.tgz",
-			"integrity": "sha512-IneIA5X+4X6eqmPqFaZNUKI7RrNRgZZJ8veqS/zGDMS8cXIK4fW1GRTsmnJ4hTmOp8eNh6N4qqiPUScQhznCMA==",
+			"version": "4.83.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.83.0.tgz",
+			"integrity": "sha512-uIuW8mB3cdssEDzdhaok/1h2q4xRTqY9/8o2iDB9Ub1vAnaPDzPaVIZypPxmIDI7+yXKiEkuwoeWpa1Gub4ppw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@wordpress/lazy-import": "^2.39.0",
+				"@wordpress/lazy-import": "^2.40.0",
 				"chalk": "^4.0.0",
 				"change-case": "^4.1.2",
 				"check-node-version": "^4.1.0",
@@ -10124,9 +10078,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.39.0.tgz",
-			"integrity": "sha512-5NSKdRd2o+qBkcx6SDaHG1Ow/EkT578SgVsRzzz3BwSRSvUee8+oDYq4SmtNIqRr7Fz5AOONL5jaluMPJBwlbQ==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.40.0.tgz",
+			"integrity": "sha512-C6QZUieZoOEeZqT265EGIn95vIA1Nt6BPCOi1JyuJQ2hxOgk/cz4Vj7a31zJzCu/c1BKN3R6n78lB6nAuyZrVQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10148,9 +10102,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.39.0.tgz",
-			"integrity": "sha512-ok008Rd8URqNQCzx/9bClC+gk7XxVV+xm5rOJjb6A4EHR8tVlynJEcE4gN0C5qCDIeOdPLbGW8ljNm2DxlelwQ==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.40.0.tgz",
+			"integrity": "sha512-7EMx/5R0l9mlR4s01I06x8bw7qq30VlU98T/tvYJa+ycFQK3oetkoPyiNfki2Y2SILQGjI3Mu4MSV1NPCa/mEw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10170,14 +10124,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
-			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.40.0.tgz",
+			"integrity": "sha512-OhU8B2xEGg7c41rh/VRiJLOz6TnM/r5r8sraAg5ISc2bF7s2oAFqLwvlR0/U6ervyYwbK644osWZGQxFyL3huA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.39.0",
+				"@wordpress/escape-html": "^3.40.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -10189,9 +10143,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.39.0.tgz",
-			"integrity": "sha512-YhAmZYQsOnnfafMwInzy/M1AR77O59u4aaIVSqiQjvCLkY+BQABsU6AizDckCg57mF2SoDnARl6xQY/7FCwEmw==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.40.0.tgz",
+			"integrity": "sha512-DD6xWVbnw4fGGgO6DFDTJiLj52om0OG4cYHLz7ZhuipmOlEUGljPYOcrj8uxtlh5EFrqHCIPkOya+qQXUHUSBw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -10261,13 +10215,14 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "11.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
-			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.7.0.tgz",
+			"integrity": "sha512-t+z65fn98A/Y4x+nynMQuJfz2v0sCfpsxa/+xopmOne/4Yt7H5/224sUc6zWV0NrIlWTDscD0QepUZ5j1qFM0Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.39.0",
-				"@wordpress/primitives": "^4.39.0"
+				"@wordpress/element": "^6.40.0",
+				"@wordpress/primitives": "^4.40.0",
+				"change-case": "4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10278,9 +10233,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.39.0.tgz",
-			"integrity": "sha512-/fgtytFExodPPI3596s/zW8vf+7P56Oqw7AK1wQycfP1biemVQcXHYr4GKpHiahZsuHuYKr/FubmN36zs9SW0Q==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.40.0.tgz",
+			"integrity": "sha512-H7j9Afosm0TvppBjQmXxErUBdWIT0u1mX+toH1liafp0gpxzowYMbv1MAASgAEzPrbL/U0P68GIW3PQXQFO4xg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10296,13 +10251,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.39.0.tgz",
-			"integrity": "sha512-rFaz2wY88acg6TFiE4/goo0UBiLMgk0u+WaKd/nYO1Nk7sei0qromabEQO2LPJyAs0SZqbz3fFhcibueFMWFwA==",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.40.0.tgz",
+			"integrity": "sha512-JkH6Hsesy6cyH+encol7jvQyMtFQYLZyb/VpUrZAfUfymOh7VtSqLSGVyxvw64OLcWKE+cE/xkApvvGFBHzG4w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.39.0",
+				"@wordpress/jest-console": "^8.40.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -10315,9 +10270,9 @@
 			}
 		},
 		"node_modules/@wordpress/lazy-import": {
-			"version": "2.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-2.39.0.tgz",
-			"integrity": "sha512-CBF3GfZGb/KasOoVVODL3IXopdfsNS+8zPQbAuk6yrBG0r/ciCGorpMR0mWQRrt5+WIyUHDyQMfDdDrd3MQnDQ==",
+			"version": "2.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-2.40.0.tgz",
+			"integrity": "sha512-kjXLutYP660FLueuGw1ILGL2CpMsUIgMLjg7+Ma4HuGHnOFYwbVGWSjGzzARXWL6Glr79SWRNqd9nlVSexQzUg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10331,9 +10286,9 @@
 			}
 		},
 		"node_modules/@wordpress/lazy-import/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -10344,9 +10299,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.39.0.tgz",
-			"integrity": "sha512-svfW7oLwTh6sRp42ATnr18H6wo1qibwercDEz2zsFg/LmWQ4h4agBhsiaDFdDFLgs7KbVwvZUzwgMvytBO9yAw==",
+			"version": "5.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.40.0.tgz",
+			"integrity": "sha512-fxIya56Bf+LTnDR07RfAM5VfITl7uQm9kJkY4nUYNRC6xPj5cCLLsIh0x5UWXmYQxTTaSreMKYxDPe4UN7tATA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10358,13 +10313,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.39.0.tgz",
-			"integrity": "sha512-r1KaBbrQSnMNOiE58gGU66RxoksRxEIo87BSdEy2tOREUz9Eoa4NExzJmnTmuC786CjadlPsn95Q98x9OWDlNQ==",
+			"version": "5.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.40.0.tgz",
+			"integrity": "sha512-t8zryWpd6sLUVWbFLkRW9637Nmvx4Odnyu9jQCV5yfLXRubD37x/PVRVx7tUw9SpbbrPzKB4DqpNOF+dTHaICg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.15.0",
+				"@wordpress/base-styles": "^6.16.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -10377,9 +10332,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.39.0.tgz",
-			"integrity": "sha512-w9NPuyKZ8y7xLNRaXOK6TLw0HdcA9vQBmK65cd16w4WxyPwXwFVGBdwoi2og/RN3UBQLYci25zGp7GtiiVhG+Q==",
+			"version": "4.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.40.0.tgz",
+			"integrity": "sha512-6JqPLZtoO1OnZJMVrWy+wwoCrJKD1VZnfNMLvNhhRoY7VypBXk189iyWj26JbOhBfFqIcVQNLNMTt9uTZDNujA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10391,12 +10346,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.39.0.tgz",
-			"integrity": "sha512-RV9s+KzyuS8p0YKczLecmhFAtOHIWkCToHyDSmRf8N3XOy4id/T0+B5SJ2nMZJleG1oYINf5lrVcccqP2VmFJg==",
+			"version": "4.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.40.0.tgz",
+			"integrity": "sha512-0gOw3n3kSUsAPo91xNDS9J4GGTrNXU90XmuWn7mNfXAl5uRAMRnxgkfL+pwd0ng0rmdPtjPqrJpljnP2oy3K2w==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.39.0",
+				"@wordpress/element": "^6.40.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -10408,9 +10363,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.39.0.tgz",
-			"integrity": "sha512-ssMAzKtjPV/T1IEFWNSVeaecKG3mhRHYHPMy2Ajh7V8RpOCyYBOZ48kZGyOwd25uzQX5k634tmfW27qJ/SMVQA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.40.0.tgz",
+			"integrity": "sha512-68cwZKVq8Xy8GBzKoDRuV4b3pQ4nJFItY689HXp+poc0XXrnAeC4ZhjeSgS1qGRpFo6RVvLjjcaZsN2OrSSMvQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10419,25 +10374,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "31.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.4.0.tgz",
-			"integrity": "sha512-yy69Ef1YvUdBu980WWPgtuRlqCvQVw28BzqWdXcrxVKTBb11H+nX1ovJPLukmPFM6QXc4ku9y89MWAa1ywMA4w==",
+			"version": "31.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.5.0.tgz",
+			"integrity": "sha512-7OS5bpHtnuagG8k9q9BdilHjhQ0MLhY0ypDgnRom5WlgPBshM/SUaF9bQLDnSDeasiD/bIgaDmoxWkfVZ4qSPQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.39.0",
-				"@wordpress/browserslist-config": "^6.39.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.39.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.39.0",
-				"@wordpress/eslint-plugin": "^24.1.0",
-				"@wordpress/jest-preset-default": "^12.39.0",
-				"@wordpress/npm-package-json-lint-config": "^5.39.0",
-				"@wordpress/postcss-plugins-preset": "^5.39.0",
-				"@wordpress/prettier-config": "^4.39.0",
-				"@wordpress/stylelint-config": "^23.31.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.40.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.40.0",
+				"@wordpress/eslint-plugin": "^24.2.0",
+				"@wordpress/jest-preset-default": "^12.40.0",
+				"@wordpress/npm-package-json-lint-config": "^5.40.0",
+				"@wordpress/postcss-plugins-preset": "^5.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/stylelint-config": "^23.32.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -10493,7 +10448,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.57.0",
+				"@playwright/test": "^1.58.2",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -10536,18 +10491,18 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-			"version": "24.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.1.0.tgz",
-			"integrity": "sha512-pYFV1XA2uWgryzdTB/IPF8vVO5MsduKIKBEpQFzPhvazZH5Gvc7orVpO5ZGIvkxKbFLNGmYdAUy2Cj0ng+tSdQ==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.2.0.tgz",
+			"integrity": "sha512-FBVWV+wZ1vN6fpSZVI8gMOJ8M1q69Lp1jMUzbH46lE+ICKnQDUeX6FkN/dZiG6rOSbHau+qEGbuPwTDe2D3quQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.39.0",
-				"@wordpress/prettier-config": "^4.39.0",
-				"@wordpress/theme": "^0.6.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/theme": "^0.7.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -11129,14 +11084,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.31.0.tgz",
-			"integrity": "sha512-+Vy769qVrjnSqCZCMolh5dHu1np+iZKkICQoccgF/VXXjp+dYLJaDzXqbKqtGU87oirUT7Q1tqWNovbuaBowIA==",
+			"version": "23.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.32.0.tgz",
+			"integrity": "sha512-CvkKISBezOyzq6yc3+9ZnX0ar2qv3LGB1T8EcawCcwpESyVdfGu8vP7VZMKI8jDmsl2fUXXzt5nDScpXctY17Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
-				"@wordpress/theme": "^0.6.0",
+				"@wordpress/theme": "^0.7.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -11150,14 +11105,14 @@
 			}
 		},
 		"node_modules/@wordpress/theme": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.6.0.tgz",
-			"integrity": "sha512-n/O1djUn+jny46JyqCwD77nPV4zCUBIn+0ICp8fDYLXpQ7FfCfCrEfhlkQkcVB45KC1iu6IMAsLOA/9hzavHoQ==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.7.0.tgz",
+			"integrity": "sha512-ULwLCSKYraIsv83bVH+Hm5pGFen6/0/8xOXQwxMdxeU+8kSm0cTKlpQPNvJGCmAeQb2OgFcowB/8wrUdyqW8UQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.39.0",
-				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/element": "^6.40.0",
+				"@wordpress/private-apis": "^1.40.0",
 				"colorjs.io": "^0.6.0",
 				"memize": "^2.1.0"
 			},
@@ -11177,9 +11132,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.39.0.tgz",
-			"integrity": "sha512-NV2WoU4XxTqZU/3k2D5m5cHIw/uM2dlDgW5u1U5fmFIYLGg43WWMlSHQEu6F4tm7fqFt7k4qwT/FymucqHYp7Q==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.40.0.tgz",
+			"integrity": "sha512-0l3OFa1Z+UdhWRRHX9JWWKofo7Lbi2MqOFzzzn0MC26HOyfieQycjLVLNVNXaaodIKUhap6uDQq+JXbbHm881A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11224,9 +11179,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -11270,9 +11225,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11303,9 +11258,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11348,9 +11303,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11790,9 +11745,9 @@
 			"license": "MIT"
 		},
 		"node_modules/atomically": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
-			"integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11864,14 +11819,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-			"integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+			"version": "1.13.5",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
@@ -12066,9 +12021,9 @@
 			}
 		},
 		"node_modules/bare-fs": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
-			"integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+			"integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -12092,9 +12047,9 @@
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-			"integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
+			"integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -12114,14 +12069,15 @@
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-			"integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
+			"integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"streamx": "^2.21.0"
+				"streamx": "^2.21.0",
+				"teex": "^1.0.1"
 			},
 			"peerDependencies": {
 				"bare-buffer": "*",
@@ -12179,18 +12135,21 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.19",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-			"integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-			"integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12701,9 +12660,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001767",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
-			"integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
+			"version": "1.0.30001774",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+			"integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -13158,13 +13117,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -13574,13 +13526,13 @@
 			}
 		},
 		"node_modules/css-functions-list": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-			"integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12 || >=16"
+				"node": ">=12"
 			}
 		},
 		"node_modules/css-has-pseudo": {
@@ -13685,9 +13637,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13763,9 +13715,9 @@
 			}
 		},
 		"node_modules/cssdb": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.7.1.tgz",
-			"integrity": "sha512-+F6LKx48RrdGOtE4DT5jz7Uo+VeyKXpK797FAevIkzjV8bMHz6xTO5F7gNDcRCHmPgD5jj2g6QCsY9zmVrh38A==",
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.8.0.tgz",
+			"integrity": "sha512-QbLeyz2Bgso1iRlh7IpWk6OKa3lLNGXsujVjDMPl9rOZpxKeiG69icLpbLCFxeURwmcdIfZqQyhlooKJYM4f8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -14567,9 +14519,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.286",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-			"integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+			"version": "1.5.302",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+			"integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
 			"license": "ISC"
 		},
 		"node_modules/emittery": {
@@ -15253,17 +15205,6 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
-		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -15285,19 +15226,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
@@ -15445,9 +15373,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -15482,9 +15410,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -15522,30 +15450,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-			}
-		},
-		"node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/eslint-plugin-playwright": {
@@ -15641,17 +15545,6 @@
 				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
 			}
 		},
-		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint-plugin-react/node_modules/doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -15665,32 +15558,25 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/eslint-plugin-react/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.5",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"version": "2.0.0-next.6",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -15736,17 +15622,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
-		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
@@ -15835,19 +15710,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/eslint/node_modules/p-locate": {
@@ -16541,17 +16403,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/flat-cache/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/flat-cache/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -16572,19 +16423,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/flat-cache/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/flat-cache/node_modules/rimraf": {
@@ -16976,9 +16814,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
-			"integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17042,18 +16880,6 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/global-modules": {
 			"version": "0.2.3",
@@ -17300,9 +17126,9 @@
 			}
 		},
 		"node_modules/hashery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
-			"integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+			"integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17718,30 +17544,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/ignore-walk/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/image-ssim": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
@@ -18075,9 +17877,9 @@
 			}
 		},
 		"node_modules/is-bun-module/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -18635,9 +18437,9 @@
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -18928,17 +18730,6 @@
 				}
 			}
 		},
-		"node_modules/jest-config/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/jest-config/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -18959,19 +18750,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/jest-config/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/jest-dev-server": {
@@ -19508,17 +19286,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-runtime/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/jest-runtime/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -19539,19 +19306,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/jest-snapshot": {
@@ -19587,9 +19341,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -19955,9 +19709,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
-			"integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.1.tgz",
+			"integrity": "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19976,9 +19730,9 @@
 			}
 		},
 		"node_modules/lefthook": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.0.tgz",
-			"integrity": "sha512-+vS+yywGQW6CN1J1hbGkez//6ixGHIQqfxDN/d3JDm531w9GfGt2lAWTDfZTw/CEl80XsN0raFcnEraR3ldw9g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.1.tgz",
+			"integrity": "sha512-Tl9h9c+sG3ShzTHKuR3LAIblnnh+Mgxnm2Ul7yu9cu260Z27LEbO3V6Zw4YZFP59/2rlD42pt/llYsQCkkCFzw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -19986,22 +19740,22 @@
 				"lefthook": "bin/index.js"
 			},
 			"optionalDependencies": {
-				"lefthook-darwin-arm64": "2.1.0",
-				"lefthook-darwin-x64": "2.1.0",
-				"lefthook-freebsd-arm64": "2.1.0",
-				"lefthook-freebsd-x64": "2.1.0",
-				"lefthook-linux-arm64": "2.1.0",
-				"lefthook-linux-x64": "2.1.0",
-				"lefthook-openbsd-arm64": "2.1.0",
-				"lefthook-openbsd-x64": "2.1.0",
-				"lefthook-windows-arm64": "2.1.0",
-				"lefthook-windows-x64": "2.1.0"
+				"lefthook-darwin-arm64": "2.1.1",
+				"lefthook-darwin-x64": "2.1.1",
+				"lefthook-freebsd-arm64": "2.1.1",
+				"lefthook-freebsd-x64": "2.1.1",
+				"lefthook-linux-arm64": "2.1.1",
+				"lefthook-linux-x64": "2.1.1",
+				"lefthook-openbsd-arm64": "2.1.1",
+				"lefthook-openbsd-x64": "2.1.1",
+				"lefthook-windows-arm64": "2.1.1",
+				"lefthook-windows-x64": "2.1.1"
 			}
 		},
 		"node_modules/lefthook-darwin-arm64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.0.tgz",
-			"integrity": "sha512-u2hjHLQXWSFfzO7ln2n/uEydSzfC9sc5cDC7tvKSuOdhvBwaJ0AQ7ZeuqqCQ4YfVIJfYOom1SVE9CBd10FVyig==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.1.tgz",
+			"integrity": "sha512-O/RS1j03/Fnq5zCzEb2r7UOBsqPeBuf1C5pMkIJcO4TSE6hf3rhLUkcorKc2M5ni/n5zLGtzQUXHV08/fSAT3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -20013,9 +19767,9 @@
 			]
 		},
 		"node_modules/lefthook-darwin-x64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.0.tgz",
-			"integrity": "sha512-zz5rcyrtOZpxon7uE+c0KC/o2ypJeLZql5CL0Y9oaTuECbmhfokm8glsGnyWstW/++PuMpZYYr/qsCJA5elxkQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.1.tgz",
+			"integrity": "sha512-mm/kdKl81ROPoYnj9XYk5JDqj+/6Al8w/SSPDfhItkLJyl4pqS+hWUOP6gDGrnuRk8S0DvJ2+hzhnDsQnZohWQ==",
 			"cpu": [
 				"x64"
 			],
@@ -20027,9 +19781,9 @@
 			]
 		},
 		"node_modules/lefthook-freebsd-arm64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.0.tgz",
-			"integrity": "sha512-+mXNCNuFHNGYLrDqYWDeHH7kWCLCJFPpspx5PAAm+PD37PRMZJrTqDbaNK9qCghC1tdmT4/Lvilf/ewXHPlaKw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.1.tgz",
+			"integrity": "sha512-F7JXlKmjxGqGbCWPLND0bVB4DMQezIe48pEwTlUQZbxh450c2gP5Q8FdttMZKOT163kBGGTqJAJSEC6zW+QSxA==",
 			"cpu": [
 				"arm64"
 			],
@@ -20041,9 +19795,9 @@
 			]
 		},
 		"node_modules/lefthook-freebsd-x64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.0.tgz",
-			"integrity": "sha512-+AU2HD7szuDsUdHue/E3OnF84B2ae/h7CGKpuIUHJntgoJ4kxf89oDvq2/xl8kDCn9cT76UUjgeZUgFYLRj+6Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.1.tgz",
+			"integrity": "sha512-Po8/lJMqNzKSZPuEI46dLuWoBoXtAxCuRpeOh6DAV/M4RhBynaCu8rLMZ9BqF7cVbZEWoplOmYo6HdOuiYpCkQ==",
 			"cpu": [
 				"x64"
 			],
@@ -20055,9 +19809,9 @@
 			]
 		},
 		"node_modules/lefthook-linux-arm64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.0.tgz",
-			"integrity": "sha512-KM70eV1tsEib1/tk+3TFxIdH84EaYlIg5KTQWAg+LB1N23nTQ7lL4Dnh1je6f6KW4tf21nmoMUqsh0xvMkQk8Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.1.tgz",
+			"integrity": "sha512-mI2ljFgPEqHxI8vrN9nKgnVu63Rz1KisDbPwlvs7BTYNwq3sncdK5ukpGR4zzWdh6saNJ5tCtHEtep5GQI11nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -20069,9 +19823,9 @@
 			]
 		},
 		"node_modules/lefthook-linux-x64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.0.tgz",
-			"integrity": "sha512-6Bxmv+l7LiYq9W0IE6v2lmlRtBp6pisnlzhcouMGvH3rDwEGw11NAyRJZA3IPGEMAkIuhnlnVTUwAUzKomfJLg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.1.tgz",
+			"integrity": "sha512-m3G/FaxC+crxeg9XeaUuHfEoL+i9gbkg2Hp2KD2IcVVIxprqlyqf0Hb8zbLV2NMXuo5RSGokJu44oAoTO3Ou2g==",
 			"cpu": [
 				"x64"
 			],
@@ -20083,9 +19837,9 @@
 			]
 		},
 		"node_modules/lefthook-openbsd-arm64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.0.tgz",
-			"integrity": "sha512-ppJNK0bBSPLC8gqksRw5zI/0uLeMA5cK+hmZ4ofcuGNmdrN1dfl2Tx84fdeef0NcQY0ii9Y3j3icIKngIoid/g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.1.tgz",
+			"integrity": "sha512-gz/8FJPvhjOdOFt1GmFvuvDOe+W+BBRjoeAT1/mTgkN7HCXMXgqNjjvakQKQeGz1I1v08wXG1ZNf5y+T9XBCDQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -20097,9 +19851,9 @@
 			]
 		},
 		"node_modules/lefthook-openbsd-x64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.0.tgz",
-			"integrity": "sha512-8k9lQsMYqQGu4spaQ8RNSOJidxIcOyfaoF2FPZhthtBfRV3cgVFGrsQ0hbIi5pvQRGUlCqYuCN79qauXHmnL3Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.1.tgz",
+			"integrity": "sha512-ch3lyMUtbmtWUufaQVn4IoEs/2hjK51XqaCdY1mh5ca//VctR1peknIwQ5feHu+vATCDviWQ7HsdNDewm3HMPg==",
 			"cpu": [
 				"x64"
 			],
@@ -20111,9 +19865,9 @@
 			]
 		},
 		"node_modules/lefthook-windows-arm64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.0.tgz",
-			"integrity": "sha512-0WN+grrxt9zP9NGRcztoPXcz25tteem91rfLWgQFab+50csJ47zldlsB7/eOS/eHG5mUg5g5NPR4XefnXtjOcQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.1.tgz",
+			"integrity": "sha512-mm3PZhKDs9FE/jQDimkfWxtoj9xQ2k8uw2MdhtC825bhvIh+MEi0WFj/MOW+ug0RBg0I55tGYzZ5aVuozAWpTQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -20125,9 +19879,9 @@
 			]
 		},
 		"node_modules/lefthook-windows-x64": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.0.tgz",
-			"integrity": "sha512-XbO/5nAZQLpUn0tPpgCYfFBFJHnymSglQ73jD6wymNrR1j8I5EcXGlP6YcLhnZ83yzsdLC+gup+N6IqUeiyRdw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.1.tgz",
+			"integrity": "sha512-1L2oGIzmhfOTxfwbe5mpSQ+m3ilpvGNymwIhn4UHq6hwHsUL6HEhODqx02GfBn6OXpVIr56bvdBAusjL/SVYGQ==",
 			"cpu": [
 				"x64"
 			],
@@ -20232,9 +19986,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.11.2",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
-			"integrity": "sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+			"integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -20242,7 +19996,7 @@
 				"extract-zip": "^2.0.1",
 				"progress": "^2.0.3",
 				"proxy-agent": "^6.5.0",
-				"semver": "^7.7.3",
+				"semver": "^7.7.4",
 				"tar-fs": "^3.1.1",
 				"yargs": "^17.7.2"
 			},
@@ -20261,18 +20015,18 @@
 			"license": "MIT"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.36.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.1.tgz",
-			"integrity": "sha512-L7ykMWc3lQf3HS7ME3PSjp7wMIjJeW6+bKfH/RSTz5l6VUDGubnrC2BKj3UvM28Y5PMDFW0xniJOZHBZPpW1dQ==",
+			"version": "24.37.5",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
+			"integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.11.2",
-				"chromium-bidi": "13.0.1",
+				"@puppeteer/browsers": "2.13.0",
+				"chromium-bidi": "14.0.0",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1551306",
+				"devtools-protocol": "0.0.1566079",
 				"typed-query-selector": "^2.12.0",
-				"webdriver-bidi-protocol": "0.4.0",
+				"webdriver-bidi-protocol": "0.4.1",
 				"ws": "^8.19.0"
 			},
 			"engines": {
@@ -20280,9 +20034,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
-			"integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+			"integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -20294,9 +20048,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1551306",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
-			"integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
+			"version": "0.0.1566079",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+			"integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -20323,9 +20077,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -20693,17 +20447,6 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/markdownlint-cli/node_modules/commander": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
@@ -20736,19 +20479,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/markdownlint-cli/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -20770,19 +20500,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/markdownlint-rule-helpers": {
@@ -21072,19 +20789,15 @@
 			"license": "ISC"
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+			"integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=10"
 			}
 		},
 		"node_modules/minimist": {
@@ -21133,11 +20846,11 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -21317,6 +21030,25 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/node-forge": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
@@ -21357,9 +21089,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -21412,9 +21144,9 @@
 			}
 		},
 		"node_modules/npm-package-arg/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -21465,9 +21197,9 @@
 			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -21519,17 +21251,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/npm-packlist/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/npm-packlist/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -21550,19 +21271,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm-packlist/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -22363,14 +22071,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-			"integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.58.1"
+				"playwright-core": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -22383,9 +22091,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-			"integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -22570,9 +22278,9 @@
 			}
 		},
 		"node_modules/postcss-color-functional-notation": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-8.0.1.tgz",
-			"integrity": "sha512-f1itLOG10iAa9mBAAtIHj/wfDs3srsNv/vrAsiRrIOfTCjhjxHxL1g06vvpQ86he2BP5HwB4cN72EZQ8rkegpA==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-8.0.2.tgz",
+			"integrity": "sha512-tbmkk6teYpJzFcGwPIhN1gkvxqGHvNx2PMb8Y3S5Ktyn7xOlvD98XzQ99MFY5mAyvXWclDG+BgoJKYJXFJOp5Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -22586,7 +22294,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -22600,9 +22308,9 @@
 			}
 		},
 		"node_modules/postcss-color-functional-notation/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -22620,9 +22328,9 @@
 			}
 		},
 		"node_modules/postcss-color-functional-notation/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -22644,9 +22352,9 @@
 			}
 		},
 		"node_modules/postcss-color-functional-notation/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -22660,8 +22368,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -22805,9 +22513,9 @@
 			}
 		},
 		"node_modules/postcss-custom-media": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-12.0.0.tgz",
-			"integrity": "sha512-jIgEvqceN6ru2uQ0f75W1g+JDi0UyECFeJKjPG7UcSkW3+03LDKH2c6h+9C0XuDTV4y2pEHmD5AJtVBq1OGnZA==",
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-12.0.1.tgz",
+			"integrity": "sha512-66syE14+VeqkUf0rRX0bvbTCbNRJF132jD+ceo8th1dap2YJEAqpdh5uG98CE3IbgHT7m9XM0GIlOazNWqQdeA==",
 			"dev": true,
 			"funding": [
 				{
@@ -22925,9 +22633,9 @@
 			}
 		},
 		"node_modules/postcss-custom-properties": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-15.0.0.tgz",
-			"integrity": "sha512-FsD3VNtFr3qmspvIobDRszK9onKPHp8iHG4Aox2Nnm9SL93uw5GDw4z+NM7zWKiw6U+DSNm24JUm4coyIyanzQ==",
+			"version": "15.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-15.0.1.tgz",
+			"integrity": "sha512-cuyq8sd8dLY0GLbelz1KB8IMIoDECo6RVXMeHeXY2Uw3Q05k/d1GVITdaKLsheqrHbnxlwxzSRZQQ5u+rNtbMg==",
 			"dev": true,
 			"funding": [
 				{
@@ -23022,9 +22730,9 @@
 			}
 		},
 		"node_modules/postcss-custom-selectors": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-9.0.0.tgz",
-			"integrity": "sha512-VuV5tLPAm6wq1u699dsrhGCzfLobKe0eD3G8bw3BcTJt6wqQ7RQdfaveJVsCAi23OaQbjIi3K1C7Fj3yZH3f1g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-9.0.1.tgz",
+			"integrity": "sha512-2XBELy4DmdVKimChfaZ2id9u9CSGYQhiJ53SvlfBvMTzLMW2VxuMb9rHsMSQw9kRq/zSbhT5x13EaK8JSmK8KQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -23469,9 +23177,9 @@
 			}
 		},
 		"node_modules/postcss-lab-function": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-8.0.1.tgz",
-			"integrity": "sha512-Q/ANnuCYtanAc+2NnCaZrYu+GofYQUV603JXL0KB6GlcXxpnm/UerPAmpKQdb9pxYUkpKovGxfL43aOUnpF/Hg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-8.0.2.tgz",
+			"integrity": "sha512-1ZIAh8ODhZdnAb09Aq2BTenePKS1G/kUR0FwvzkQDfFtSOV64Ycv27YvV11fDycEvhIcEmgYkLABXKRiWcXRuA==",
 			"dev": true,
 			"funding": [
 				{
@@ -23485,7 +23193,7 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
@@ -23499,9 +23207,9 @@
 			}
 		},
 		"node_modules/postcss-lab-function/node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -23519,9 +23227,9 @@
 			}
 		},
 		"node_modules/postcss-lab-function/node_modules/@csstools/css-calc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-			"integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -23543,9 +23251,9 @@
 			}
 		},
 		"node_modules/postcss-lab-function/node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -23559,8 +23267,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.1.1"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -23654,9 +23362,9 @@
 			}
 		},
 		"node_modules/postcss-loader/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -24285,9 +23993,9 @@
 			}
 		},
 		"node_modules/postcss-preset-env": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-11.1.2.tgz",
-			"integrity": "sha512-rtRQeKP7xZgAAE4YSxjYyX62qpgn9n7BczxtpA0AP4u9JYn1wfUhsd3ZmV9mi8IlU111aF1TtJMqT/QhmtAgLA==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-11.2.0.tgz",
+			"integrity": "sha512-eNYpuj68cjGjvZMoSAbHilaCt3yIyzBL1cVuSGJfvJewsaBW/U6dI2bqCJl3iuZsL+yvBobcy4zJFA/3I68IHQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -24301,19 +24009,20 @@
 			],
 			"license": "MIT-0",
 			"dependencies": {
-				"@csstools/postcss-alpha-function": "^2.0.2",
+				"@csstools/postcss-alpha-function": "^2.0.3",
 				"@csstools/postcss-cascade-layers": "^6.0.0",
-				"@csstools/postcss-color-function": "^5.0.1",
-				"@csstools/postcss-color-function-display-p3-linear": "^2.0.1",
-				"@csstools/postcss-color-mix-function": "^4.0.1",
-				"@csstools/postcss-color-mix-variadic-function-arguments": "^2.0.1",
+				"@csstools/postcss-color-function": "^5.0.2",
+				"@csstools/postcss-color-function-display-p3-linear": "^2.0.2",
+				"@csstools/postcss-color-mix-function": "^4.0.2",
+				"@csstools/postcss-color-mix-variadic-function-arguments": "^2.0.2",
 				"@csstools/postcss-content-alt-text": "^3.0.0",
-				"@csstools/postcss-contrast-color-function": "^3.0.1",
-				"@csstools/postcss-exponential-functions": "^3.0.0",
+				"@csstools/postcss-contrast-color-function": "^3.0.2",
+				"@csstools/postcss-exponential-functions": "^3.0.1",
 				"@csstools/postcss-font-format-keywords": "^5.0.0",
-				"@csstools/postcss-gamut-mapping": "^3.0.1",
-				"@csstools/postcss-gradients-interpolation-method": "^6.0.1",
-				"@csstools/postcss-hwb-function": "^5.0.1",
+				"@csstools/postcss-font-width-property": "^1.0.0",
+				"@csstools/postcss-gamut-mapping": "^3.0.2",
+				"@csstools/postcss-gradients-interpolation-method": "^6.0.2",
+				"@csstools/postcss-hwb-function": "^5.0.2",
 				"@csstools/postcss-ic-unit": "^5.0.0",
 				"@csstools/postcss-initial": "^3.0.0",
 				"@csstools/postcss-is-pseudo-class": "^6.0.0",
@@ -24323,39 +24032,39 @@
 				"@csstools/postcss-logical-overscroll-behavior": "^3.0.0",
 				"@csstools/postcss-logical-resize": "^4.0.0",
 				"@csstools/postcss-logical-viewport-units": "^4.0.0",
-				"@csstools/postcss-media-minmax": "^3.0.0",
+				"@csstools/postcss-media-minmax": "^3.0.1",
 				"@csstools/postcss-media-queries-aspect-ratio-number-values": "^4.0.0",
 				"@csstools/postcss-mixins": "^1.0.0",
 				"@csstools/postcss-nested-calc": "^5.0.0",
 				"@csstools/postcss-normalize-display-values": "^5.0.1",
-				"@csstools/postcss-oklab-function": "^5.0.1",
+				"@csstools/postcss-oklab-function": "^5.0.2",
 				"@csstools/postcss-position-area-property": "^2.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^5.0.0",
 				"@csstools/postcss-property-rule-prelude-list": "^2.0.0",
-				"@csstools/postcss-random-function": "^3.0.0",
-				"@csstools/postcss-relative-color-syntax": "^4.0.1",
+				"@csstools/postcss-random-function": "^3.0.1",
+				"@csstools/postcss-relative-color-syntax": "^4.0.2",
 				"@csstools/postcss-scope-pseudo-class": "^5.0.0",
-				"@csstools/postcss-sign-functions": "^2.0.0",
-				"@csstools/postcss-stepped-value-functions": "^5.0.0",
+				"@csstools/postcss-sign-functions": "^2.0.1",
+				"@csstools/postcss-stepped-value-functions": "^5.0.1",
 				"@csstools/postcss-syntax-descriptor-syntax-production": "^2.0.0",
 				"@csstools/postcss-system-ui-font-family": "^2.0.0",
-				"@csstools/postcss-text-decoration-shorthand": "^5.0.1",
-				"@csstools/postcss-trigonometric-functions": "^5.0.0",
+				"@csstools/postcss-text-decoration-shorthand": "^5.0.3",
+				"@csstools/postcss-trigonometric-functions": "^5.0.1",
 				"@csstools/postcss-unset-value": "^5.0.0",
-				"autoprefixer": "^10.4.23",
+				"autoprefixer": "^10.4.24",
 				"browserslist": "^4.28.1",
 				"css-blank-pseudo": "^8.0.1",
 				"css-has-pseudo": "^8.0.0",
 				"css-prefers-color-scheme": "^11.0.0",
-				"cssdb": "^8.7.0",
+				"cssdb": "^8.8.0",
 				"postcss-attribute-case-insensitive": "^8.0.0",
 				"postcss-clamp": "^4.1.0",
-				"postcss-color-functional-notation": "^8.0.1",
+				"postcss-color-functional-notation": "^8.0.2",
 				"postcss-color-hex-alpha": "^11.0.0",
 				"postcss-color-rebeccapurple": "^11.0.0",
-				"postcss-custom-media": "^12.0.0",
-				"postcss-custom-properties": "^15.0.0",
-				"postcss-custom-selectors": "^9.0.0",
+				"postcss-custom-media": "^12.0.1",
+				"postcss-custom-properties": "^15.0.1",
+				"postcss-custom-selectors": "^9.0.1",
 				"postcss-dir-pseudo-class": "^10.0.0",
 				"postcss-double-position-gradients": "^7.0.0",
 				"postcss-focus-visible": "^11.0.0",
@@ -24363,7 +24072,7 @@
 				"postcss-font-variant": "^5.0.0",
 				"postcss-gap-properties": "^7.0.0",
 				"postcss-image-set-function": "^8.0.0",
-				"postcss-lab-function": "^8.0.1",
+				"postcss-lab-function": "^8.0.2",
 				"postcss-logical": "^9.0.0",
 				"postcss-nesting": "^14.0.0",
 				"postcss-opacity-percentage": "^3.0.0",
@@ -24985,9 +24694,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -25526,17 +25235,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/resp-modifier/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/resp-modifier/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -25545,19 +25243,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
-			}
-		},
-		"node_modules/resp-modifier/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/resp-modifier/node_modules/ms": {
@@ -25621,22 +25306,6 @@
 			},
 			"bin": {
 				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -25850,9 +25519,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "16.0.6",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-			"integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25866,7 +25535,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 				"sass": "^1.3.0",
 				"sass-embedded": "*",
@@ -25980,9 +25649,9 @@
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -26840,9 +26509,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.22",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -27468,9 +27137,9 @@
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.27.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.0.tgz",
-			"integrity": "sha512-/pUmP9UebM48q5BTqZd0yPnDjyRGhITbKh8cwa6/ZwjuDu8xq+VzmugLF7QNxpdaqqNH3J5nnv3yc8oARv096A==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -27844,9 +27513,9 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/swiper": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.0.tgz",
-			"integrity": "sha512-BD4CpAOOyEvZ2f0CDx362ea+vmOwukVcmbsQx+0BhRIaBUz8wvcCd//E7RFmvBZCrfyqXCHUVqmgUwts6ywlxw==",
+			"version": "12.1.2",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.2.tgz",
+			"integrity": "sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==",
 			"funding": [
 				{
 					"type": "patreon",
@@ -27903,9 +27572,9 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -27968,9 +27637,9 @@
 			}
 		},
 		"node_modules/tar-stream/node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+			"integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
@@ -27980,6 +27649,17 @@
 				"react-native-b4a": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"streamx": "^2.12.5"
 			}
 		},
 		"node_modules/terser": {
@@ -28110,17 +27790,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/test-exclude/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -28143,23 +27812,10 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -28167,9 +27823,9 @@
 			}
 		},
 		"node_modules/text-decoder/node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+			"integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
@@ -28271,20 +27927,20 @@
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.21",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.21.tgz",
-			"integrity": "sha512-oVOMdHvgjqyzUZH1rOESgJP1uNe2bVrfK0jUHHmiM2rpEiRbf3j4BrsIc6JigJRbHGanQwuZv/R+LTcHsw+bLA==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "7.0.21",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.21.tgz",
-			"integrity": "sha512-cO9tYYUAz1LJ3NV22UdQSCvfVPvUDhNyvyS3UgPUuj3e//TgUOqqo7xnp2z/KI4PmfoBIITKxxL5vLSqneZndg==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.23.tgz",
+			"integrity": "sha512-LMc6V1KOHFjKDU8wyDsIEJdV8o2bpc2OaYw2NxncJB2oZxJMPpiNVAbiu1HnqsUy81fkK1QWwFztVqY81hUFEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.21"
+				"tldts-core": "^7.0.23"
 			}
 		},
 		"node_modules/tldts/node_modules/tldts-core": {
@@ -29065,9 +28721,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/webdriver-bidi-protocol": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
-			"integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+			"integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -29082,9 +28738,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.105.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
-			"integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+			"version": "5.105.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+			"integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -29329,17 +28985,6 @@
 				}
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/webpack-dev-server/node_modules/connect-history-api-fallback": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -29370,19 +29015,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/rimraf": {
@@ -29489,9 +29121,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
 	"bugs": {
 		"email": "admin@tri.be"
 	},
+	"overrides": {
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0",
+		"minimatch": "5.1.8"
+	},
 	"browserslist": [
 		"defaults",
 		"not ios < 17.5",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
 	},
 	"overrides": {
 		"react": "^18.0.0",
-		"react-dom": "^18.0.0",
-		"minimatch": "5.1.8"
+		"react-dom": "^18.0.0"
 	},
 	"browserslist": [
 		"defaults",


### PR DESCRIPTION
## Summary
- Adds `overrides` block to `package.json` to pin `react` and `react-dom` to `^18.0.0`, preventing npm from resolving React 19 (via `@dnd-kit`'s loose `>=16.8.0` peer dep) which conflicts with `@wordpress/icons` and `@wordpress/scripts`
- Ported from [nexcess-2026#8](https://github.com/moderntribe/nexcess-2026/pull/8)

## Test plan
- [ ] Delete `node_modules` and `package-lock.json`, then run `npm install` — should complete without errors
- [ ] Run `npm run build` to verify blocks compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)