### PR TITLE
Feature/moose 351/border settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 - Updated: `npm run create-block` script template files updated.
 - Added: New Accordion block styling
 - Added: support for custom ACF Color Picker field integration.
+- Updated: `theme.json` border controls are now enabled only for `core/group`, `core/columns`, and `core/cover`.
+- Fixed: Block editor panel label now shows "Border & Shadow" via a centralized editor filter workaround for [Gutenberg issue #60192](https://github.com/WordPress/gutenberg/issues/60192).
 - Removed: Details block styling
 - Fixed: pre-push git hooks running properly again.
 

--- a/wp-content/themes/core/assets/js/editor/filters/index.js
+++ b/wp-content/themes/core/assets/js/editor/filters/index.js
@@ -1,0 +1,32 @@
+/**
+ * @module editor-filters
+ *
+ * @description Registers editor-level filters.
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+const shadowLabel = 'Shadow';
+const borderAndShadowLabel = __('Border & Shadow', 'tribe');
+
+const relabelShadowLabel = ( translation, text ) => {
+	if ( text !== shadowLabel ) {
+		return translation;
+	}
+
+	return borderAndShadowLabel;
+};
+
+const init = () => {
+	// TODO: As of WP 6.9.4, this workaround is needed for a Gutenberg [label bug](https://github.com/WordPress/gutenberg/issues/60192).
+	// The bug is not directly related to the issue in that report, but rather the fact that enabling border or shadow via theme.json breaks that label logic.
+	// Revisit and remove if core fixes it or if this causes editor interference.
+	addFilter(
+		'i18n.gettext',
+		'tribe/relabel-shadow-label',
+		relabelShadowLabel
+	);
+};
+
+export default init;

--- a/wp-content/themes/core/assets/js/editor/filters/index.js
+++ b/wp-content/themes/core/assets/js/editor/filters/index.js
@@ -1,32 +1,35 @@
 /**
  * @module editor-filters
  *
- * @description Registers editor-level filters.
+ * @description Registers editor-level UI workarounds.
  */
 
-import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
-const shadowLabel = 'Shadow';
-const borderAndShadowLabel = __( 'Border & Shadow', 'tribe' );
+const panelHeadingSelector = 'h2.components-heading';
+const shadowHeading = 'Shadow';
+const borderAndShadowHeading = __( 'Border & Shadow', 'tribe' );
 
-const relabelShadowLabel = ( translation, text ) => {
-	if ( text !== shadowLabel ) {
-		return translation;
-	}
+const relabelShadowPanelHeading = () => {
+	const headings = document.querySelectorAll( panelHeadingSelector );
 
-	return borderAndShadowLabel;
+	headings.forEach( ( heading ) => {
+		if ( heading.textContent?.trim() !== shadowHeading ) {
+			return;
+		}
+
+		heading.textContent = borderAndShadowHeading;
+	} );
 };
 
 const init = () => {
-	// TODO: As of WP 6.9.4, this workaround is needed for a Gutenberg [label bug](https://github.com/WordPress/gutenberg/issues/60192).
-	// The bug is not directly related to the issue in that report, but rather the fact that enabling border or shadow via theme.json breaks that label logic.
+	// TODO: As of WP 6.9.4, this workaround is needed for a Gutenberg label bug.
+	// Ref: https://github.com/WordPress/gutenberg/issues/60192
 	// Revisit and remove if core fixes it or if this causes editor interference.
-	addFilter(
-		'i18n.gettext',
-		'tribe/relabel-shadow-label',
-		relabelShadowLabel
-	);
+	relabelShadowPanelHeading();
+
+	const observer = new MutationObserver( relabelShadowPanelHeading );
+	observer.observe( document.body, { childList: true, subtree: true } );
 };
 
 export default init;

--- a/wp-content/themes/core/assets/js/editor/filters/index.js
+++ b/wp-content/themes/core/assets/js/editor/filters/index.js
@@ -8,7 +8,7 @@ import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 const shadowLabel = 'Shadow';
-const borderAndShadowLabel = __('Border & Shadow', 'tribe');
+const borderAndShadowLabel = __( 'Border & Shadow', 'tribe' );
 
 const relabelShadowLabel = ( translation, text ) => {
 	if ( text !== shadowLabel ) {

--- a/wp-content/themes/core/assets/js/editor/ready.js
+++ b/wp-content/themes/core/assets/js/editor/ready.js
@@ -6,6 +6,7 @@
 
 import blockAnimations from './block-animations';
 import colorPicker from './color-picker';
+import filters from './filters';
 
 /**
  * @function init
@@ -14,6 +15,7 @@ import colorPicker from './color-picker';
 
 const init = () => {
 	// initialize block animation controls in editor
+	filters();
 	blockAnimations();
 	colorPicker();
 

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -192,11 +192,11 @@
 				}
 			}
 		},
-		"border":{
-			"color":false,
-			"radius":false,
-			"style":false,
-			"width":false
+		"border": {
+			"color": false,
+			"radius": false,
+			"style": false,
+			"width": false
 		},
 		"color": {
 			"background": false,

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -44,13 +44,22 @@
 				}
 			},
 			"core/columns": {
+				"border": {
+					"color": true,
+					"radius": true,
+					"style": true,
+					"width": true
+				},
 				"spacing": {
 					"blockGap": true
 				}
 			},
 			"core/cover": {
 				"border": {
-					"radius": true
+					"color": true,
+					"radius": true,
+					"style": true,
+					"width": true
 				}
 			},
 			"core/details": {
@@ -66,6 +75,13 @@
 				}
 			},
 			"core/group": {
+				"border": {
+					"color": true,
+					"radius": true,
+					"style": true,
+					"width": true
+				},
+				"shadow": true,
 				"color": {
 					"background": true
 				},
@@ -175,6 +191,12 @@
 					"blockGap": true
 				}
 			}
+		},
+		"border":{
+			"color":false,
+			"radius":false,
+			"style":false,
+			"width":false
 		},
 		"color": {
 			"background": false,


### PR DESCRIPTION
## What does this do/fix?

This pull request adds and configures border support for several core blocks in the theme, and introduces a JavaScript filter to relabel the "Shadow" option in the editor UI for improved clarity. The changes also include a workaround for a known Gutenberg label bug.

The most important changes are:

**Editor UI Improvements:**

* Added a new `filters` module (`editor/filters/index.js`) that registers an i18n filter to relabel the "Shadow" label to "Border & Shadow" in the block editor, addressing a Gutenberg label bug. This filter is initialized as part of the editor setup. [[1]](diffhunk://#diff-8a0b136f77918b16dd61c7d86f19bf09bc18fab4be0050e7c9442c9071a55164R1-R32) [[2]](diffhunk://#diff-c8f5cfb14362d0b2c9ca90900ec86637ad2649c70135fb6897303421ae5a99aeR9) [[3]](diffhunk://#diff-c8f5cfb14362d0b2c9ca90900ec86637ad2649c70135fb6897303421ae5a99aeR18)

**Theme Block Support Enhancements:**

* Enabled border support (color, radius, style, width) for `core/columns`, `core/cover`, and `core/group` blocks in `theme.json`. [[1]](diffhunk://#diff-97117d177c4fb952d83071f364b336ac94a1f80e2d8c39f76f03d46014fb140cR47-R62) [[2]](diffhunk://#diff-97117d177c4fb952d83071f364b336ac94a1f80e2d8c39f76f03d46014fb140cR78-R84)
* Enabled shadow support for the `core/group` block in `theme.json`.

**Global Theme Settings:**

* Added global border settings to `theme.json`, explicitly disabling border color, radius, style, and width by default to ensure block-level control.
## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-351)

Screenshots/video:
- [Link to Video](https://www.loom.com/i/bf77885103f14a338c7eae2982858a4b)

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] I've captured a screenshot or screencast of the changes and linked it above.
