### PR TITLE
[MOOSE-372] FE: `ServerSideRender` should use named import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 - Updated: Refactor Horizontal Tabs block into a dynamic block. Add reordering functionality. 
 - Updated: Refactor Vertical Tabs block to dynamic block; allow sorting.
+- Updated: All blocks that use the `ServerSideRender` package now properly pull from the named import instead of the default import (deprecated).
 
 ## [2026.02]
 - Added: `moderntribe/tribe_embed` composer package v1.1.0.

--- a/dev/templates/block/edit.js.mustache
+++ b/dev/templates/block/edit.js.mustache
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
 {{#isDynamicVariant}}
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 {{/isDynamicVariant}}
 
 import './editor.pcss';

--- a/wp-content/themes/core/blocks/tribe/announcement-renderer/edit.js
+++ b/wp-content/themes/core/blocks/tribe/announcement-renderer/edit.js
@@ -1,5 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 
 export default function Edit( { attributes } ) {
 	const blockProps = useBlockProps();

--- a/wp-content/themes/core/blocks/tribe/icon-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/icon-card/edit.js
@@ -16,7 +16,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import { useMemo, useState } from '@wordpress/element';
 import IconPicker from 'components/IconPicker';
 import { formatIconName } from 'blocks/tribe/icon-picker/utils';

--- a/wp-content/themes/core/blocks/tribe/image-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/image-card/edit.js
@@ -20,7 +20,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import { withSelect } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
 import blockSettings from './block.json';

--- a/wp-content/themes/core/blocks/tribe/image-overlay-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/image-overlay-card/edit.js
@@ -20,7 +20,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import { withSelect } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
 import DynamicColorPicker from 'components/DynamicColorPicker';

--- a/wp-content/themes/core/blocks/tribe/masthead-search/edit.js
+++ b/wp-content/themes/core/blocks/tribe/masthead-search/edit.js
@@ -1,5 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 
 import './editor.pcss';
 

--- a/wp-content/themes/core/blocks/tribe/menu-toggle/edit.js
+++ b/wp-content/themes/core/blocks/tribe/menu-toggle/edit.js
@@ -1,5 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 
 import './editor.pcss';
 

--- a/wp-content/themes/core/blocks/tribe/post-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/post-card/edit.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import metadata from './block.json';
 
 export default function Edit( {

--- a/wp-content/themes/core/blocks/tribe/related-posts/edit.js
+++ b/wp-content/themes/core/blocks/tribe/related-posts/edit.js
@@ -7,7 +7,7 @@ import {
 	SelectControl,
 	ToggleControl,
 } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import { withSelect } from '@wordpress/data';
 
 function Edit( { props, postList } ) {

--- a/wp-content/themes/core/blocks/tribe/search-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/search-card/edit.js
@@ -1,5 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import metadata from './block.json';
 
 export default function Edit( { context } ) {

--- a/wp-content/themes/core/blocks/tribe/terms/edit.js
+++ b/wp-content/themes/core/blocks/tribe/terms/edit.js
@@ -2,7 +2,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/server-side-render';
 
 function Edit( { props, taxonomies } ) {
 	const blockProps = useBlockProps();


### PR DESCRIPTION
## What does this do/fix?

This pull request updates all blocks that use the `ServerSideRender` package to import it as a named import instead of a default import, following the deprecation of the default import. This change ensures compatibility with the latest WordPress package standards and prevents potential issues with future updates.

**Refactoring imports for `ServerSideRender`:**

* Updated all usages of `ServerSideRender` across multiple block editor files to use named imports (`import { ServerSideRender } from '@wordpress/server-side-render';`) instead of default imports. This affects blocks such as `announcement-renderer`, `icon-card`, `image-card`, `image-overlay-card`, `masthead-search`, `menu-toggle`, `post-card`, `related-posts`, `search-card`, and `terms` (`wp-content/themes/core/blocks/tribe/announcement-renderer/edit.js` [[1]](diffhunk://#diff-cd2e0dbc48c2c324590058d198c6c36e0f047b61fd90ea42ea2997f3b7ee6da6L2-R2) `wp-content/themes/core/blocks/tribe/icon-card/edit.js` [[2]](diffhunk://#diff-55339b14012b57df23d83e5934a42cee7ba7b839cb4528cbdd080e39504688daL19-R19) `wp-content/themes/core/blocks/tribe/image-card/edit.js` [[3]](diffhunk://#diff-4d386eb5c36a0a5157ee1fefa9ac331f18b2c1cc29424dde08f7559d5f978199L23-R23) `wp-content/themes/core/blocks/tribe/image-overlay-card/edit.js` [[4]](diffhunk://#diff-975a324e585b9e62c290b7a96c48b6fdd303906d327272e3cc4f89f277ae0873L23-R23) `wp-content/themes/core/blocks/tribe/masthead-search/edit.js` [[5]](diffhunk://#diff-1aa68e3c919defa26def15c97c806a6d45ecffcf56fac492a06d172213f72f63L2-R2) `wp-content/themes/core/blocks/tribe/menu-toggle/edit.js` [[6]](diffhunk://#diff-a056816202c242919b23c940bea6b765b34290919c1e78d66d13c797b78ccb3eL2-R2) `wp-content/themes/core/blocks/tribe/post-card/edit.js` [[7]](diffhunk://#diff-ef070f0db2db8fce4d72ea44afb33042f28e717518c77f0d6c757c63d393c0baL4-R4) `wp-content/themes/core/blocks/tribe/related-posts/edit.js` [[8]](diffhunk://#diff-f14e1392b1de129684a0fe4c8541c6c63de7bdb4eb717d2a257c2c5df37c38e1L10-R10) `wp-content/themes/core/blocks/tribe/search-card/edit.js` [[9]](diffhunk://#diff-6b6ff2f6b84a225f59272f40c086124491b0a44c8c0a1d546e69ea7e2b2c3af6L2-R2) `wp-content/themes/core/blocks/tribe/terms/edit.js` [[10]](diffhunk://#diff-1769def2362f21265db2b2f6231e8672dc6ca1e242167e3139706707cc92a655L5-R5) `dev/templates/block/edit.js.mustache` [[11]](diffhunk://#diff-2142f279889ab998e2df22bb788817887b848cb3633c1cedb9819100366bdc78L5-R5).
* Documented this update in the `CHANGELOG.md` to note the migration to named imports for all blocks using the `ServerSideRender` package.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-372)

Dev Environment
- http://moose-dev-pr339.d1.moderntribe.qa/

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] ~~I've captured a screenshot or screencast of the changes and linked it above.~~ N/A
