### PR TITLE
[MOOSE-373] FE: Add `MediaImageControl` Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 - Updated: Refactor Horizontal Tabs block into a dynamic block. Add reordering functionality. 
 - Updated: Refactor Vertical Tabs block to dynamic block; allow sorting.
+- Updated: Image / Image Overlay blocks now use a shared `MediaImageControl` component instead of adding the media control separately.
 
 ## [2026.02]
 - Added: `moderntribe/tribe_embed` composer package v1.1.0.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,6 +142,7 @@ module.exports = {
 			components: resolve(
 				'./wp-content/themes/core/assets/js/components'
 			),
+			hooks: resolve( './wp-content/themes/core/assets/js/hooks' ),
 		},
 	},
 	entry: {

--- a/wp-content/themes/core/assets/js/components/MediaImageControl.js
+++ b/wp-content/themes/core/assets/js/components/MediaImageControl.js
@@ -1,0 +1,160 @@
+import { __ } from '@wordpress/i18n';
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import {
+	BaseControl,
+	Button,
+	Flex,
+	FlexItem,
+	ResponsiveWrapper,
+	Spinner,
+	VisuallyHidden,
+} from '@wordpress/components';
+import { useBlockMedia } from 'hooks/useBlockMedia';
+
+const previewTriggerStyle = {
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	width: '100%',
+	minHeight: '120px',
+	boxSizing: 'border-box',
+};
+
+const missingMessageStyle = {
+	textAlign: 'center',
+	maxWidth: '100%',
+	lineHeight: 1.4,
+	padding: '0.5rem 0.25rem',
+};
+
+/**
+ * Inspector control for choosing, previewing, replacing, and removing an image
+ * from the media library (featured-image-style UI). Loads attachment data via
+ * `useBlockMedia`; pass only `mediaId` from block attributes.
+ *
+ * @param {Object}        props
+ * @param {number|string} props.mediaId        Attachment ID, or 0 when empty (coerced like `useBlockMedia`).
+ * @param {Function}      props.onSelect       Called with the selected media object from MediaUpload.
+ * @param {Function}      props.onRemove       Called when the user removes the image.
+ * @param {string}        [props.label]        Visual label for the control.
+ * @param {string[]}      [props.allowedTypes] Passed to MediaUpload.
+ * @param {string}        [props.chooseLabel]  Empty-state button text.
+ * @param {string}        [props.replaceLabel] Replace flow label and button text.
+ * @param {string}        [props.removeLabel]  Remove button text.
+ * @param {string}        [props.missingLabel] Shown when the ID is set but the attachment cannot be loaded.
+ */
+export default function MediaImageControl( {
+	mediaId,
+	onSelect,
+	onRemove,
+	label = __( 'Image', 'tribe' ),
+	allowedTypes = [ 'image' ],
+	chooseLabel = __( 'Choose an image', 'tribe' ),
+	replaceLabel = __( 'Replace image', 'tribe' ),
+	removeLabel = __( 'Remove image', 'tribe' ),
+	missingLabel = __(
+		'Could not load image data. Try replacing the image.',
+		'tribe'
+	),
+} ) {
+	const { media, isLoading, isMissing } = useBlockMedia( mediaId );
+
+	const width = media?.media_details?.width;
+	const height = media?.media_details?.height;
+	const src = media?.source_url;
+	const altFromMedia = media?.alt_text ?? media?.media_details?.alt ?? '';
+	const previewAlt = altFromMedia || __( 'Selected image', 'tribe' );
+
+	const previewImage =
+		src &&
+		( width && height ? (
+			<ResponsiveWrapper naturalWidth={ width } naturalHeight={ height }>
+				<img src={ src } alt={ previewAlt } />
+			</ResponsiveWrapper>
+		) : (
+			<img src={ src } alt={ previewAlt } />
+		) );
+
+	return (
+		<BaseControl __nextHasNoMarginBottom>
+			<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
+			<MediaUploadCheck>
+				<MediaUpload
+					allowedTypes={ allowedTypes }
+					onSelect={ onSelect }
+					value={ mediaId }
+					render={ ( { open } ) => (
+						<Button
+							className={
+								mediaId === 0
+									? 'editor-post-featured-image__toggle'
+									: 'editor-post-featured-image__preview'
+							}
+							style={
+								mediaId !== 0 ? previewTriggerStyle : undefined
+							}
+							onClick={ open }
+							aria-busy={ mediaId !== 0 && isLoading }
+						>
+							{ mediaId === 0 && chooseLabel }
+							{ mediaId !== 0 && isLoading && (
+								<>
+									<VisuallyHidden as="span">
+										{ __( 'Loading image', 'tribe' ) }
+									</VisuallyHidden>
+									<Spinner />
+								</>
+							) }
+							{ mediaId !== 0 && ! isLoading && isMissing && (
+								<span style={ missingMessageStyle }>
+									{ missingLabel }
+								</span>
+							) }
+							{ mediaId !== 0 &&
+								! isLoading &&
+								! isMissing &&
+								previewImage }
+						</Button>
+					) }
+				/>
+			</MediaUploadCheck>
+			{ mediaId !== 0 && (
+				<Flex
+					style={ {
+						marginTop: '1rem',
+					} }
+				>
+					<FlexItem>
+						<MediaUploadCheck>
+							<MediaUpload
+								title={ replaceLabel }
+								value={ mediaId }
+								onSelect={ onSelect }
+								allowedTypes={ allowedTypes }
+								render={ ( { open } ) => (
+									<Button
+										onClick={ open }
+										variant="secondary"
+									>
+										{ replaceLabel }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</FlexItem>
+					<FlexItem>
+						<MediaUploadCheck>
+							<Button
+								variant="link"
+								isDestructive
+								onClick={ onRemove }
+							>
+								{ removeLabel }
+							</Button>
+						</MediaUploadCheck>
+					</FlexItem>
+				</Flex>
+			) }
+		</BaseControl>
+	);
+}

--- a/wp-content/themes/core/assets/js/hooks/useBlockMedia.js
+++ b/wp-content/themes/core/assets/js/hooks/useBlockMedia.js
@@ -1,0 +1,65 @@
+import { useSelect } from '@wordpress/data';
+
+/**
+ * REST query passed to `getEntityRecord` for attachment posts. Kept as a stable
+ * reference so `hasFinishedResolution` matches the resolver cache key (same
+ * pattern as core’s post featured image control).
+ */
+const ATTACHMENT_RECORD_QUERY = { context: 'view' };
+
+/**
+ * Subscribe to a media attachment from the `core` data store via
+ * `getEntityRecord( 'postType', 'attachment', id, query )`.
+ *
+ * Uses the attachment post type instead of the legacy `getMedia` shortcut so
+ * this stays aligned with current Gutenberg data APIs.
+ *
+ * @param {number|string} mediaId Attachment ID from block attributes, or 0 / empty when none. Numeric strings are coerced.
+ * @return {{ media: Object|undefined|null, hasResolved: boolean, isLoading: boolean, isMissing: boolean }} `media` is `undefined` while loading; falsy after resolution if the attachment is missing or was deleted.
+ */
+export function useBlockMedia( mediaId ) {
+	let id = 0;
+	if ( typeof mediaId === 'number' && mediaId > 0 ) {
+		id = mediaId;
+	} else {
+		const n = Number( mediaId );
+		if ( n > 0 ) {
+			id = n;
+		}
+	}
+
+	return useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return {
+					media: undefined,
+					hasResolved: true,
+					isLoading: false,
+					isMissing: false,
+				};
+			}
+
+			const { getEntityRecord, hasFinishedResolution } = select( 'core' );
+			const media = getEntityRecord(
+				'postType',
+				'attachment',
+				id,
+				ATTACHMENT_RECORD_QUERY
+			);
+			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				'attachment',
+				id,
+				ATTACHMENT_RECORD_QUERY,
+			] );
+
+			return {
+				media,
+				hasResolved,
+				isLoading: ! hasResolved,
+				isMissing: hasResolved && ! media,
+			};
+		},
+		[ id ]
+	);
+}

--- a/wp-content/themes/core/blocks/tribe/image-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/image-card/edit.js
@@ -3,31 +3,24 @@ import {
 	BlockControls,
 	InspectorControls,
 	LinkControl,
-	MediaUpload,
-	MediaUploadCheck,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
-	BaseControl,
-	Button,
-	Flex,
-	FlexItem,
 	PanelBody,
 	Popover,
-	ResponsiveWrapper,
 	TextareaControl,
 	TextControl,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
-import { withSelect } from '@wordpress/data';
+import MediaImageControl from 'components/MediaImageControl';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import { useMemo, useState } from '@wordpress/element';
 import blockSettings from './block.json';
 
 import './editor.pcss';
 
-const Edit = ( { attributes, setAttributes, isSelected, media } ) => {
+export default function Edit( { attributes, setAttributes, isSelected } ) {
 	const blockProps = useBlockProps();
 
 	const {
@@ -149,100 +142,11 @@ const Edit = ( { attributes, setAttributes, isSelected, media } ) => {
 			{ isSelected && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Block Settings', 'tribe' ) }>
-						<BaseControl __nextHasNoMarginBottom>
-							<BaseControl.VisualLabel>
-								{ __( 'Image', 'tribe' ) }
-							</BaseControl.VisualLabel>
-							<MediaUploadCheck>
-								<MediaUpload
-									allowedTypes={ [ 'image' ] }
-									onSelect={ onSelectMedia }
-									value={ mediaId }
-									render={ ( { open } ) => (
-										<Button
-											className={
-												mediaId === 0
-													? 'editor-post-featured-image__toggle'
-													: 'editor-post-featured-image__preview'
-											}
-											onClick={ open }
-										>
-											{ mediaId === 0 &&
-												__(
-													'Choose an image',
-													'tribe'
-												) }
-											{ media !== undefined && (
-												<ResponsiveWrapper
-													naturalWidth={
-														media.media_details
-															.width
-													}
-													naturalHeight={
-														media.media_details
-															.height
-													}
-												>
-													<img
-														src={ media.source_url }
-														alt={
-															media.media_details
-																.alt
-														}
-													/>
-												</ResponsiveWrapper>
-											) }
-										</Button>
-									) }
-								/>
-							</MediaUploadCheck>
-							{ mediaId !== 0 && (
-								<Flex
-									style={ {
-										marginTop: '1rem',
-									} }
-								>
-									<FlexItem>
-										<MediaUploadCheck>
-											<MediaUpload
-												title={ __(
-													'Replace image',
-													'tribe'
-												) }
-												value={ mediaId }
-												onSelect={ onSelectMedia }
-												allowedTypes={ [ 'image' ] }
-												render={ ( { open } ) => (
-													<Button
-														onClick={ open }
-														variant="secondary"
-													>
-														{ __(
-															'Replace image',
-															'tribe'
-														) }
-													</Button>
-												) }
-											/>
-										</MediaUploadCheck>
-									</FlexItem>
-									<FlexItem>
-										<MediaUploadCheck>
-											<Button
-												onClick={ removeMedia }
-												isLink
-												isDestructive
-											>
-												{ __(
-													'Remove image',
-													'tribe'
-												) }
-											</Button>
-										</MediaUploadCheck>
-									</FlexItem>
-								</Flex>
-							) }
-						</BaseControl>
+						<MediaImageControl
+							mediaId={ mediaId }
+							onSelect={ onSelectMedia }
+							onRemove={ removeMedia }
+						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
@@ -309,15 +213,4 @@ const Edit = ( { attributes, setAttributes, isSelected, media } ) => {
 			) }
 		</div>
 	);
-};
-
-/**
- * Pass the media object to the Edit function as a prop.
- */
-export default withSelect( ( select, props ) => {
-	return {
-		media: props.attributes.mediaId
-			? select( 'core' ).getMedia( props.attributes.mediaId )
-			: undefined,
-	};
-} )( Edit );
+}

--- a/wp-content/themes/core/blocks/tribe/image-overlay-card/edit.js
+++ b/wp-content/themes/core/blocks/tribe/image-overlay-card/edit.js
@@ -3,32 +3,25 @@ import {
 	BlockControls,
 	InspectorControls,
 	LinkControl,
-	MediaUpload,
-	MediaUploadCheck,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
-	BaseControl,
-	Button,
-	Flex,
-	FlexItem,
 	PanelBody,
 	Popover,
-	ResponsiveWrapper,
 	TextControl,
 	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import ServerSideRender from '@wordpress/server-side-render';
-import { withSelect } from '@wordpress/data';
+import MediaImageControl from 'components/MediaImageControl';
+import { ServerSideRender } from '@wordpress/server-side-render';
 import { useMemo, useState } from '@wordpress/element';
 import DynamicColorPicker from 'components/DynamicColorPicker';
 import blockSettings from './block.json';
 
 import './editor.pcss';
 
-const Edit = ( { attributes, setAttributes, isSelected, media } ) => {
+export default function Edit( { attributes, setAttributes, isSelected } ) {
 	const blockProps = useBlockProps();
 
 	const {
@@ -152,100 +145,11 @@ const Edit = ( { attributes, setAttributes, isSelected, media } ) => {
 			{ isSelected && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Block Settings', 'tribe' ) }>
-						<BaseControl __nextHasNoMarginBottom>
-							<BaseControl.VisualLabel>
-								{ __( 'Image', 'tribe' ) }
-							</BaseControl.VisualLabel>
-							<MediaUploadCheck>
-								<MediaUpload
-									allowedTypes={ [ 'image' ] }
-									onSelect={ onSelectMedia }
-									value={ mediaId }
-									render={ ( { open } ) => (
-										<Button
-											className={
-												mediaId === 0
-													? 'editor-post-featured-image__toggle'
-													: 'editor-post-featured-image__preview'
-											}
-											onClick={ open }
-										>
-											{ mediaId === 0 &&
-												__(
-													'Choose an image',
-													'tribe'
-												) }
-											{ media !== undefined && (
-												<ResponsiveWrapper
-													naturalWidth={
-														media.media_details
-															.width
-													}
-													naturalHeight={
-														media.media_details
-															.height
-													}
-												>
-													<img
-														src={ media.source_url }
-														alt={
-															media.media_details
-																.alt
-														}
-													/>
-												</ResponsiveWrapper>
-											) }
-										</Button>
-									) }
-								/>
-							</MediaUploadCheck>
-							{ mediaId !== 0 && (
-								<Flex
-									style={ {
-										marginTop: '1rem',
-									} }
-								>
-									<FlexItem>
-										<MediaUploadCheck>
-											<MediaUpload
-												title={ __(
-													'Replace image',
-													'tribe'
-												) }
-												value={ mediaId }
-												onSelect={ onSelectMedia }
-												allowedTypes={ [ 'image' ] }
-												render={ ( { open } ) => (
-													<Button
-														onClick={ open }
-														variant="secondary"
-													>
-														{ __(
-															'Replace image',
-															'tribe'
-														) }
-													</Button>
-												) }
-											/>
-										</MediaUploadCheck>
-									</FlexItem>
-									<FlexItem>
-										<MediaUploadCheck>
-											<Button
-												onClick={ removeMedia }
-												isLink
-												isDestructive
-											>
-												{ __(
-													'Remove image',
-													'tribe'
-												) }
-											</Button>
-										</MediaUploadCheck>
-									</FlexItem>
-								</Flex>
-							) }
-						</BaseControl>
+						<MediaImageControl
+							mediaId={ mediaId }
+							onSelect={ onSelectMedia }
+							onRemove={ removeMedia }
+						/>
 						<DynamicColorPicker
 							controlLabel={ __(
 								'Default Overlay Color',
@@ -332,15 +236,4 @@ const Edit = ( { attributes, setAttributes, isSelected, media } ) => {
 			) }
 		</div>
 	);
-};
-
-/**
- * Pass the media object to the Edit function as a prop.
- */
-export default withSelect( ( select, props ) => {
-	return {
-		media: props.attributes.mediaId
-			? select( 'core' ).getMedia( props.attributes.mediaId )
-			: undefined,
-	};
-} )( Edit );
+}


### PR DESCRIPTION
## What does this do/fix?

Introduces a reusable **`MediaImageControl`** for the block editor sidebar and refactors the **image card** and **image overlay card** blocks to use it, so image pick/preview/replace/remove behavior lives in one place.

## What changed

- **`MediaImageControl`** (`assets/js/components/MediaImageControl.js`) — Featured-image–style UI: choose image, preview (with `ResponsiveWrapper` when dimensions exist), replace/remove actions, loading spinner + `VisuallyHidden` text, missing-attachment messaging, and **inline layout styles** so editor polish stays in the component file (no new stylesheet).
- **`useBlockMedia`** (`assets/js/hooks/useBlockMedia.js`) — Subscribes to attachment data via **`getEntityRecord( 'postType', 'attachment', … )`** and **`hasFinishedResolution`**, matching core’s direction instead of the legacy `getMedia` shortcut; exposes `media`, `isLoading`, `isMissing`, and `hasResolved`.
- **`image-card`** and **`image-overlay-card`** — Removed duplicated `MediaUpload` / `withSelect` boilerplate; each block keeps `onSelect` / `onRemove` + `mediaId` and delegates UI to **`MediaImageControl`**.
- **Webpack** — Adds a **`hooks`** resolve alias pointing at `assets/js/hooks` (same idea as the existing `components` alias).

## Why

- Less duplication when adding similar blocks.
- Clear loading and missing states in the inspector.
- Data loading aligned with current core-data attachment APIs.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-373)

Screenshots/video:
- Media Image Control component: https://p.tri.be/i/PZf6CH

Dev Environment URL:
- http://moose-dev-pr340.d1.moderntribe.qa/

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] I've captured a screenshot or screencast of the changes and linked it above.
