### PR TITLE
[MOOSE-380] FE: Core Button Block "Width" Setting Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 - Updated: Refactor Horizontal Tabs block into a dynamic block. Add reordering functionality. 
 - Updated: Refactor Vertical Tabs block to dynamic block; allow sorting.
+- Updated: Button block set to "Default" style now respects the "Width" setting.
 
 ## [2026.02]
 - Added: `moderntribe/tribe_embed` composer package v1.1.0.

--- a/wp-content/themes/core/assets/pcss/actions/_mixins.pcss
+++ b/wp-content/themes/core/assets/pcss/actions/_mixins.pcss
@@ -12,7 +12,6 @@
 
 	@mixin a-btn-arrow;
 	display: inline-block;
-	width: auto;
 	height: auto;
 	position: relative;
 	background-color: var(--btn-background-color);
@@ -27,6 +26,11 @@
 	text-decoration: none;
 	text-align: left;
 	transition: var(--transition);
+
+	/* only set width to auto if button block doesn't have a custom width applied */
+	.wp-block-button:not(.has-custom-width) & {
+		width: auto;
+	}
 
 	/**
 	 * Extra right padding to accommodate the absolutely positioned arrow

--- a/wp-content/themes/core/blocks/core/button/style.pcss
+++ b/wp-content/themes/core/blocks/core/button/style.pcss
@@ -6,6 +6,7 @@
 
 .wp-block-button__link {
 
+	/* note: this selector is specific enough to override some core styles */
 	.wp-block-button:not(.is-style-outlined, .is-style-ghost) & {
 
 		@mixin a-btn;


### PR DESCRIPTION
## What does this do/fix?

This pull request updates the Button block to ensure that when set to the "Default" style, it now properly respects the "Width" setting. The main changes involve adjusting the CSS so that button width is only set to `auto` when a custom width is not applied, improving compatibility with user-defined widths.

**Button Block Width Handling:**

* The Button block set to "Default" style now respects the "Width" setting, allowing custom widths to be applied as expected.
* In `_mixins.pcss`, the `width: auto;` property is now only applied when the button block does not have a custom width, preventing it from overriding user-defined widths.
* The direct `width: auto;` declaration was removed from the mixin to avoid unintended overrides.
* Added a comment in `style.pcss` to clarify selector specificity for overriding core styles.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-380)

Testing Environment:
- http://moose-dev-pr343.d1.moderntribe.qa/

Screenshots/video:
- Default button style respects width setting: https://p.tri.be/i/Bju45y

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] I've captured a screenshot or screencast of the changes and linked it above.
