### PR TITLE
[MOOSE-365] FE: Sticky Column Positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 - Updated: Refactor Horizontal Tabs block into a dynamic block. Add reordering functionality. 
 - Updated: Refactor Vertical Tabs block to dynamic block; allow sorting.
+- Updated: Sticky Column block setting now respects masthead height.
 
 ## [2026.02]
 - Added: `moderntribe/tribe_embed` composer package v1.1.0.

--- a/wp-content/themes/core/assets/js/config/state.js
+++ b/wp-content/themes/core/assets/js/config/state.js
@@ -6,4 +6,5 @@ export default {
 	v_height: 0,
 	v_width: 0,
 	isMobileMenuShown: false,
+	headerHeight: 0,
 };

--- a/wp-content/themes/core/assets/js/theme/masthead.js
+++ b/wp-content/themes/core/assets/js/theme/masthead.js
@@ -5,9 +5,11 @@
  */
 
 import { HEADER_BREAKPOINT } from 'config/options.js';
+import globalState from 'config/state.js';
 import { triggerCustomEvent } from 'utils/events.js';
 
 const el = {
+	body: document.body,
 	header: document.querySelector( '.site-header' ),
 	navigation: document.querySelector( '.site-header__navigation' ),
 };
@@ -96,6 +98,8 @@ const handleResize = () => {
 		cloneElements();
 		createMobileMenu();
 	}
+
+	getHeaderHeight();
 };
 
 /**
@@ -120,6 +124,20 @@ const bindEvents = () => {
 };
 
 /**
+ * @function getHeaderHeight
+ *
+ * @description since the masthead is a dynamic height, we need to be able to offset the mobile menu using a CSS
+ *     property
+ */
+const getHeaderHeight = () => {
+	globalState.headerHeight = el.header.offsetHeight;
+	el.body.style.setProperty(
+		'--header-height',
+		globalState.headerHeight + 'px'
+	);
+};
+
+/**
  * @function init
  * @description Initializes the masthead by setting up elements, creating the mobile menu, and binding events.
  */
@@ -133,6 +151,7 @@ const init = () => {
 		createMobileMenu();
 	}
 
+	getHeaderHeight();
 	bindEvents();
 };
 

--- a/wp-content/themes/core/blocks/core/columns/style.pcss
+++ b/wp-content/themes/core/blocks/core/columns/style.pcss
@@ -34,7 +34,7 @@
 		@media (--mq-wp-adminbar) {
 			align-self: flex-start;
 			position: sticky;
-			top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--spacer-50)); /* stylelint-disable-line */
+			top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--header-height, 0px) + var(--spacer-50)); /* stylelint-disable-line */
 
 			.editor-styles-wrapper & {
 				top: 0;


### PR DESCRIPTION
## What does this do/fix?

This pull request updates the handling of the sticky column block and masthead (header) height to ensure that UI elements correctly respect the dynamic height of the masthead. The changes introduce a new global state for `headerHeight`, update the CSS to use this value, and ensure it is recalculated as needed. This improves layout consistency, especially when the masthead height changes dynamically.

**Sticky Column & Masthead Height Improvements:**

* Added a new `headerHeight` property to the global state in `state.js` to track the masthead height.
* Implemented a `getHeaderHeight` function in `masthead.js` to update the global state and set the CSS variable `--header-height` on the `<body>`, ensuring the masthead height is available for layout calculations.
* Called `getHeaderHeight` during both initialization and window resize in `masthead.js` to keep the header height value accurate. [[1]](diffhunk://#diff-36b4e71e19002d6a0178f7da6d342e50960f97c5a113811476e0c7865cf7f70bR101-R102) [[2]](diffhunk://#diff-36b4e71e19002d6a0178f7da6d342e50960f97c5a113811476e0c7865cf7f70bR154)
* Updated the sticky column block CSS to use the new `--header-height` variable, so sticky columns now offset correctly below the masthead.

**Documentation:**

* Updated the changelog to note that the Sticky Column block setting now respects the masthead height.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-365)

Testing Environment:
- http://moose-dev-pr344.d1.moderntribe.qa/

Screenshots/video:
- Updated sticky column positioning: https://p.tri.be/i/22rsAe

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] I've captured a screenshot or screencast of the changes and linked it above.
