### PR TITLE
[MOOSE-381] Bump Block Editor Custom Alignments Plugin Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 - Updated: Refactor Horizontal Tabs block into a dynamic block. Add reordering functionality. 
 - Updated: Refactor Vertical Tabs block to dynamic block; allow sorting.
+- Updated: Bump Block Editor Custom Alignments plugin to 1.1.3 to fix enqueuing warnings.
 
 ## [2026.02]
 - Added: `moderntribe/tribe_embed` composer package v1.1.0.

--- a/composer.json
+++ b/composer.json
@@ -65,11 +65,11 @@
 			"type": "package",
 			"package": {
 				"name": "block-editor-custom-alignments/block-editor-custom-alignments",
-				"version": "1.1.1",
+				"version": "1.1.3",
 				"type": "wordpress-plugin",
 				"dist": {
 					"type": "zip",
-					"url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.1.1/block-editor-custom-alignments.1.1.1.zip"
+					"url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.1.3/block-editor-custom-alignments.1.1.3.zip"
 				},
 				"require": {
 					"ffraenz/private-composer-installer": "^5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,14 +4,14 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c7fed3b4f52bd9dcf7164581537d01f",
+    "content-hash": "dc1b687810fccc61daabcfb145db12fe",
     "packages": [
         {
             "name": "block-editor-custom-alignments/block-editor-custom-alignments",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.1.1/block-editor-custom-alignments.1.1.1.zip"
+                "url": "https://github.com/moderntribe/block-editor-custom-alignments/releases/download/v1.1.3/block-editor-custom-alignments.1.1.3.zip"
             },
             "require": {
                 "ffraenz/private-composer-installer": "^5.0"


### PR DESCRIPTION
## What does this do/fix?

> [!NOTE]
> Version 1.1.2 was broken - had to bump to 1.1.3. 

This pull request updates the Block Editor Custom Alignments plugin to address enqueuing warnings by bumping its version. The main changes are:

**Dependency Updates:**

* Updated the `block-editor-custom-alignments/block-editor-custom-alignments` plugin version from `1.1.1` to `1.1.3` in `composer.json`, including the download URL, to pull in the latest fixes.

**Changelog:**

* Added a changelog entry noting the bump to version `1.1.3` to fix enqueuing warnings.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-381)

Testing environment:
- http://moose-dev-pr347.d1.moderntribe.qa/

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [ ] ~~I've captured a screenshot or screencast of the changes and linked it above.~~ N/A
