### PR TITLE
[MOOSE-395] FE: `theme.json` settings extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 - Updated: Related Posts now supports current post types, taxonomy-based matching, latest-item fallbacks, and mixed post type manual selection.
 - Updated: Related Posts block now uses Post Search Field component.
 - Fixed: Fixes an issue where `lando start` overwrites the host's `node_modules` with Linux binaries, causing `lefthook` to fail when making commits on macOS.
+- Updated: Open up the default block settings throughout ModernPress to allow more customization for design & client editors. New [Block Settings Support page](https://github.com/moderntribe/ModernPress/wiki/Block-Setting-Support) added to the GitHub Wiki.
 
 ## [2026.04]
 

--- a/wp-content/themes/core/assets/pcss/color/_variables.pcss
+++ b/wp-content/themes/core/assets/pcss/color/_variables.pcss
@@ -71,6 +71,13 @@
 	--box-shadow-40: var(--wp--preset--shadow--40);
 	--box-shadow-50: var(--wp--preset--shadow--50);
 	--box-shadow-60: var(--wp--preset--shadow--60);
+
+	/* -----------------------------------------------------------------------
+	 * Gradients
+	 * ----------------------------------------------------------------------- */
+
+	--gradient-simple-black-horizontal: var(--wp--preset--gradient--simple-black-horizontal);
+	--gradient-simple-black-vertical: var(--wp--preset--gradient--simple-black-vertical);
 }
 
 :root,

--- a/wp-content/themes/core/blocks/core/embed/style.pcss
+++ b/wp-content/themes/core/blocks/core/embed/style.pcss
@@ -3,6 +3,7 @@
  * Block - Embed - FE / Editor Styles
  *
  * ------------------------------------------------------------------------- */
+
 .wp-block-embed {
 
 	@mixin media-block-shared-alignment;

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -16,6 +16,7 @@
 			"core/accordion",
 			"core/accordion-heading",
 			"core/accordion-panel",
+			"core/breadcrumbs",
 			"tribe/carousel-slide",
 			"tribe/horizontal-tab",
 			"tribe/logo-marquee",

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -24,11 +24,6 @@
 		],
 		"appearanceTools": true,
 		"blocks": {
-			"core/buttons": {
-				"spacing": {
-					"blockGap": true
-				}
-			},
 			"core/button": {
 				"border": {
 					"color": false,
@@ -37,7 +32,9 @@
 					"width": false
 				},
 				"color": {
-					"text": false
+					"text": false,
+					"background": false,
+					"gradients": []
 				},
 				"shadow": [],
 				"spacing": {
@@ -45,46 +42,58 @@
 				},
 				"typography": {
 					"fontFamilies": [],
+					"customFontSize": false,
 					"fontSizes": [],
-					"textTransform": false
-				}
-			},
-			"core/columns": {
-				"spacing": {
-					"blockGap": true
+					"textTransform": false,
+					"fontWeight": false,
+					"fontStyle": false,
+					"lineHeight": false,
+					"letterSpacing": false,
+					"textDecoration": false
 				}
 			},
 			"core/group": {
-				"spacing": {
-					"blockGap": true
-				}
-			},
-			"core/navigation": {
-				"spacing": {
-					"blockGap": true
+				"color": {
+					"button": false,
+					"link": false
 				}
 			},
 			"core/post-template": {
 				"spacing": {
-					"blockGap": true
+					"blockGap": false
 				}
 			},
-			"core/social-links": {
-				"spacing": {
-					"blockGap": true
+			"core/query-pagination": {
+				"color": {
+					"link": false,
+					"text": false
 				}
 			},
-			"outermost/social-sharing": {
-				"spacing": {
-					"blockGap": true
+			"core/table": {
+				"color": {
+					"background": false,
+					"text": false
 				}
 			}
 		},
 		"color": {
+			"customDuotone": false,
 			"defaultGradients": false,
 			"defaultPalette": false,
+			"defaultDuotone": false,
 			"duotone": [],
-			"gradients": [],
+			"gradients": [
+				{
+					"slug": "simple-black-horizontal",
+					"name": "Simple horizontal gradient from transparent to black",
+					"gradient": "linear-gradient(90deg,rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)"
+				},
+				{
+					"slug": "simple-black-vertical",
+					"name": "Simple vertical gradient from transparent to black",
+					"gradient": "linear-gradient(180deg,rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)"
+				}
+			],
 			"palette": [
 				{
 					"color": "#3050E5",

--- a/wp-content/themes/core/theme.json
+++ b/wp-content/themes/core/theme.json
@@ -22,6 +22,7 @@
 			"tribe/logo-marquee",
 			"tribe/vertical-tab"
 		],
+		"appearanceTools": true,
 		"blocks": {
 			"core/buttons": {
 				"spacing": {
@@ -35,6 +36,10 @@
 					"style": false,
 					"width": false
 				},
+				"color": {
+					"text": false
+				},
+				"shadow": [],
 				"spacing": {
 					"padding": false
 				},
@@ -49,58 +54,9 @@
 					"blockGap": true
 				}
 			},
-			"core/cover": {
-				"border": {
-					"radius": true
-				}
-			},
-			"core/details": {
-				"border": {
-					"color": true,
-					"radius": false,
-					"style": false,
-					"width": true
-				},
-				"spacing": {
-					"margin": true,
-					"padding": false
-				}
-			},
 			"core/group": {
-				"color": {
-					"background": true
-				},
-				"background": {
-					"backgroundImage": true,
-					"backgroundSize": true
-				},
 				"spacing": {
 					"blockGap": true
-				}
-			},
-			"core/heading": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/image": {
-				"border": {
-					"color": true,
-					"radius": true,
-					"width": true
-				}
-			},
-			"core/list": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/list-item": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
 				}
 			},
 			"core/navigation": {
@@ -108,67 +64,14 @@
 					"blockGap": true
 				}
 			},
-			"core/paragraph": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/post-featured-image": {
-				"border": {
-					"radius": true
-				}
-			},
 			"core/post-template": {
 				"spacing": {
 					"blockGap": true
 				}
 			},
-			"core/pullquote": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/quote": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/query-pagination": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
 			"core/social-links": {
 				"spacing": {
 					"blockGap": true
-				}
-			},
-			"core/table": {
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
 				}
 			},
 			"outermost/social-sharing": {
@@ -178,15 +81,10 @@
 			}
 		},
 		"color": {
-			"background": false,
-			"custom": false,
-			"customDuotone": false,
-			"customGradient": false,
 			"defaultGradients": false,
 			"defaultPalette": false,
 			"duotone": [],
 			"gradients": [],
-			"link": false,
 			"palette": [
 				{
 					"color": "#3050E5",
@@ -230,9 +128,7 @@
 			"wideSize": "1136px"
 		},
 		"typography": {
-			"customFontSize": false,
 			"defaultFontSizes": false,
-			"dropCap": false,
 			"fluid": false,
 			"fontFamilies": [
 				{
@@ -325,14 +221,10 @@
 					"size": "round(down, clamp(3rem, 2.4rem + 3vw, 6rem), 2px)",
 					"name": "Font Size 90"
 				}
-			],
-			"fontStyle": false,
-			"fontWeight": false,
-			"letterSpacing": false,
-			"lineHeight": false,
-			"textDecoration": false
+			]
 		},
 		"shadow": {
+			"defaultPresets": false,
 			"presets": [
 				{
 					"name": "Shadow 10",
@@ -368,9 +260,6 @@
 		},
 		"spacing": {
 			"defaultSpacingSizes": false,
-			"margin": true,
-			"padding": true,
-			"blockGap": false,
 			"spacingSizes": [
 				{
 					"size": "round(down, clamp(0.25rem, 0.2rem + 0.25vw, 0.5rem), 2px)",


### PR DESCRIPTION
## What does this do/fix?

This branch broadens editor customization by leaning on WordPress **`appearanceTools`** in `theme.json` instead of maintaining long lists of per-block settings. Editors get access to the standard block design controls (spacing, borders, typography where applicable, etc.) across blocks, aligned with the new [Block Settings Support](https://github.com/moderntribe/ModernPress/wiki/Block-Setting-Support) wiki page.

**`theme.json`**

- Sets **`appearanceTools`: `true`** so core appearance-related controls are available theme-wide.
- **Removes** many explicit `settings.blocks.*` entries that were selectively enabling things like `blockGap`, borders, or typography on individual blocks (e.g. buttons, columns, cover, group, navigation, lists, query pagination children, social links, etc.). Those behaviors are now covered by global appearance tools where appropriate.
- **Keeps or tightens** a smaller set of block-specific overrides where the design system should still limit the editor, for example:
  - **`core/button`**: additional restrictions on color, shadow, typography (e.g. custom font size, font weight, line height, letter spacing, text decoration), plus existing border/spacing/typography limits.
  - **`core/group`**: link/button color controls disabled.
  - **`core/post-template`**: `blockGap` disabled.
  - **`core/query-pagination`**: text/link color disabled.
  - **`core/table`**: background/text color disabled.
- **Color**: adds **`defaultDuotone`: `false`**, registers two **theme gradients** (`simple-black-horizontal`, `simple-black-vertical`) for overlays/fades, and adjusts the color settings object (e.g. drops some prior `false` flags that are redundant or superseded by `appearanceTools`).
- **Typography**: removes several global typography feature flags and **`dropCap`** from settings (handled or implied differently with the new setup).
- **Shadow**: sets **`defaultPresets`: `false`** so only the theme’s custom shadow presets apply.
- **Spacing**: removes explicit global **`margin` / `padding` / `blockGap`** flags from `settings.spacing` so spacing behavior follows the new appearance-tools configuration.

**Styles / tokens**

- **`assets/pcss/color/_variables.pcss`**: exposes CSS variables for the new gradient presets (`--gradient-simple-black-horizontal`, `--gradient-simple-black-vertical`) mapped from `--wp--preset--gradient--*`.

**Misc**

- **`blocks/core/embed/style.pcss`**: whitespace-only formatting (blank line after file header comment).

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-395)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/6e2177c818924f9a8bbc747577c25396)

Testing environment:
- http://moose-dev-pr352.d1.moderntribe.qa/

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] I've captured a screenshot or screencast of the changes and linked it above.
