### PR TITLE
[MOOSE-399] FE: Announcement Renderer Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file. The format 
 on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the
 item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2026.05]
+
+- Updated: Announcement Renderer block adjusted to not be available in the inserter and attributes updated to actual values
+
 ## [2026.04]
+
 - Updated: all plugins, composer & npm packages to latest; pin React to v18 as an override to resolve conflicts between ` @dnd-kit/core` and `@wordpress/icons`; pin several other packages to newer versions to resolve security warnings.
 
 ## [2026.03]
@@ -23,6 +28,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 - Added: XDebug documentation
 
 ## [2026.02]
+
 - Added: `moderntribe/tribe_embed` composer package v1.1.0.
 - Updated: Renamed "Moose" to "ModernPress" across the project (excluding Lando configs and deployment pipelines).
 - Updated: Expected PHP version to v8.4, Node version to v24 LTS

--- a/wp-content/themes/core/blocks/tribe/announcement-renderer/block.json
+++ b/wp-content/themes/core/blocks/tribe/announcement-renderer/block.json
@@ -10,12 +10,17 @@
 	"attributes": {
 		"placement": {
 			"type": "string",
-			"default": "top"
+			"default": "placement_above"
 		}
 	},
 	"supports": {
+		"inserter": false,
 		"html": false,
-		"alignCustom": [ "wide", "grid", "full" ],
+		"alignCustom": [
+			"wide",
+			"grid",
+			"full"
+		],
 		"spacing": {
 			"margin": true,
 			"padding": true


### PR DESCRIPTION
## What does this do/fix?

The **Announcement Renderer** block (`tribe/announcement-renderer`) is meant to be placed via templates (for example the header), not inserted manually in the editor.

- Sets **`supports.inserter` to `false`** so the block does not appear in the block inserter.
- Updates the **`placement` attribute default** from `"top"` to **`"placement_above"`** so it matches the real placement values used elsewhere in the announcements implementation (avoids a misleading default that does not align with server-side rules).

Also adds a **CHANGELOG** entry under `[2026.05]` for these updates.

## QA

Links to relevant issues

- [MOOSE-399](https://moderntribe.atlassian.net/browse/MOOSE-399)

Screenshots/video:

- N/A for this change (block registration / defaults only; no visible UI change beyond the block no longer appearing in the inserter). If QA prefers proof, a short note that the Announcement Renderer block is absent from “+” inserter search is enough.

## Pull request checklist

- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [ ] I've captured a screenshot or screencast of the changes and linked it above. *(Optional here; see QA note.)*

[MOOSE-399]: https://moderntribe.atlassian.net/browse/MOOSE-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ