### PR TITLE
Fix a typo in color picker variable

### DIFF
--- a/wp-content/themes/core/assets/js/editor/color-picker/index.js
+++ b/wp-content/themes/core/assets/js/editor/color-picker/index.js
@@ -72,7 +72,7 @@ const mountColorPicker = ( el ) => {
 const init = () => {
 	window.MTColorPickerBridge ??= [];
 	window.MTColorPickerBridge.forEach( ( { el } ) => mountColorPicker( el ) );
-	window.MTColorPickerBridg = { push: ( { el } ) => mountColorPicker( el ) };
+	window.MTColorPickerBridge = { push: ( { el } ) => mountColorPicker( el ) };
 
 	[ 'acf/render_block_preview', 'acf/setup_fields' ].forEach( ( event ) => {
 		window.addEventListener( event, () => {


### PR DESCRIPTION
## What does this do/fix?

Fix a typo in color picker variable. 
Change from `window.MTColorPickerBridg` to `window.MTColorPickerBridge`

