### PR TITLE
Fix lando node_modules isolation

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -27,6 +27,9 @@ services:
         XDEBUG_MODE: 'debug,develop'
   node:
     type: node:24
+    overrides:
+      volumes:
+        - /app/node_modules
 
 # Enabling MailHog will cause an error on start: `/bin/sh: 1: curl: not found`.
 # Related GH Issue: https://github.com/lando/mailhog/issues/35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ item (Added, Changed, Depreciated, Removed, Fixed, Security).
 - Updated: Announcement Renderer block adjusted to not be available in the inserter and attributes updated to actual values
 - Added: View Transitions plugin.
 - Updated: Related Posts now supports current post types, taxonomy-based matching, latest-item fallbacks, and mixed post type manual selection.
+- Fixed: Fixes an issue where `lando start` overwrites the host's `node_modules` with Linux binaries, causing `lefthook` to fail when making commits on macOS.
 
 ## [2026.04]
 


### PR DESCRIPTION
## What does this do/fix?

Fixes an issue where `lando start` overwrites the host's `node_modules` with Linux binaries, causing `lefthook` to fail when making commits on macOS.

**Developer action required after merging:** Run `lando rebuild` once (not just `lando start`) to create the new volume. After that, no manual `npm install` is needed after lando restarts.

**Root cause:** The `post-start` event runs `npm install` inside the Docker `node` service (Linux container). Since the project directory is mounted as a volume, this replaces the host's macOS `node_modules` — including `lefthook`'s binary — with Linux-incompatible versions. Git hooks then fail until the developer manually runs `npm install` on the host.

**Fix:** Added a Docker anonymous volume at `/app/node_modules` in the node service. This gives the container its own isolated `node_modules` that never touches the host filesystem. The container still runs `npm install` and `npm run build` normally; the host's macOS binaries are simply left alone.